### PR TITLE
Small Fixes

### DIFF
--- a/R/CohortManifest.R
+++ b/R/CohortManifest.R
@@ -306,6 +306,12 @@ CohortManifest <- R6::R6Class(
       conn <- DBI::dbConnect(RSQLite::SQLite(), private$.dbPath)
       on.exit(DBI::dbDisconnect(conn))
 
+      previous <- DBI::dbGetQuery(
+        conn,
+        "SELECT hash, category, tags FROM cohort_manifest WHERE id = ?",
+        list(existingId)
+      )
+
       hash <- if (file.exists(file_path)) {
         rlang::hash(readr::read_file(file_path))
       } else {
@@ -324,6 +330,13 @@ CohortManifest <- R6::R6Class(
       } else {
         NA_character_
       }
+
+      # The rendered SQL captures depends_on/dependency_rule already (they're
+      # inlined into the template), so a hash diff is a proxy for any
+      # definition-affecting change
+      definition_changed <- !identical(hash, previous$hash[1])
+      metadata_changed <- !identical(as.character(category), as.character(previous$category[1])) ||
+        !identical(as.character(tags_json), as.character(previous$tags[1]))
 
       set_clauses <- paste(
         "category = ?, file_path = ?, hash = ?, source_type = ?, cohort_type = ?,",
@@ -344,7 +357,16 @@ CohortManifest <- R6::R6Class(
       # Refresh in-memory manifest
       private$load_manifest_from_db()
 
-      cli::cli_alert_info("Updated derived cohort {existingId}: {label} in place (marked stale for regeneration)")
+      change_desc <- if (definition_changed && metadata_changed) {
+        "definition and metadata updated"
+      } else if (definition_changed) {
+        "definition updated, metadata unchanged"
+      } else if (metadata_changed) {
+        "definition unchanged, metadata updated"
+      } else {
+        "no changes detected"
+      }
+      cli::cli_alert_info("Updated derived cohort {existingId}: {label} — {change_desc} (marked stale for regeneration)")
       return(existingId)
     },
 
@@ -518,7 +540,7 @@ CohortManifest <- R6::R6Class(
       if (!is_dependent && !is.na(existing_id)) {
         upsert_target <- DBI::dbGetQuery(
           conn,
-          "SELECT cohort_type, file_path, hash FROM cohort_manifest WHERE id = ?",
+          "SELECT cohort_type, file_path, hash, category, tags FROM cohort_manifest WHERE id = ?",
           list(existing_id)
         )
         if (upsert_target$cohort_type[1] != "custom") {
@@ -594,12 +616,21 @@ CohortManifest <- R6::R6Class(
       } else if (!is.na(existing_id)) {
         # Replace metadata wholesale (matching the other upsert routes): tags
         # not re-supplied here are dropped
-        private$update_cohort_def(cohortId = existing_id, category = category, tags = tags)
+        new_tags_json <- if (length(tags) > 0) jsonlite::toJSON(tags, auto_unbox = TRUE) else NA_character_
+        metadata_changed <- !identical(as.character(category), as.character(upsert_target$category[1])) ||
+          !identical(as.character(new_tags_json), as.character(upsert_target$tags[1]))
+        private$update_cohort_def(cohortId = existing_id, category = category, tags = tags, silent = TRUE)
 
         new_hash <- rlang::hash(sql_content)
-        if (identical(new_hash, upsert_target$hash[1]) &&
-            identical(as.character(rel_path), upsert_target$file_path[1])) {
-          cli::cli_alert_info("Cohort {existing_id}: {label} definition is unchanged")
+        definition_changed <- !identical(new_hash, upsert_target$hash[1]) ||
+          !identical(as.character(rel_path), upsert_target$file_path[1])
+
+        if (!definition_changed) {
+          if (metadata_changed) {
+            cli::cli_alert_info("Cohort {existing_id}: {label} — definition unchanged, metadata updated")
+          } else {
+            cli::cli_alert_info("Cohort {existing_id}: {label} — definition and metadata unchanged")
+          }
         } else {
           DBI::dbExecute(
             conn,
@@ -608,6 +639,12 @@ CohortManifest <- R6::R6Class(
           )
           # Derived cohorts built on this definition are now out of date
           private$cascade_stale_downstream(existing_id)
+
+          if (metadata_changed) {
+            cli::cli_alert_success("Updated cohort {existing_id}: {label} — definition and metadata updated")
+          } else {
+            cli::cli_alert_success("Updated cohort {existing_id}: {label} — definition updated, metadata unchanged")
+          }
         }
 
         private$load_manifest_from_db()
@@ -625,7 +662,7 @@ CohortManifest <- R6::R6Class(
         )
       }
 
-      return(cohort_id)
+      return(invisible(list(id = cohort_id, isNew = is.na(existing_id))))
     },
 
     # Insert a new cohort into SQLite and refresh in-memory manifest
@@ -709,7 +746,7 @@ CohortManifest <- R6::R6Class(
     # Update metadata for an existing cohort
     # Modifies label, category, or tags for a cohort entry in the manifest.
     # The file path remains immutable.
-    update_cohort_def = function(cohortId, label = NULL, category = NULL, tags = NULL) {
+    update_cohort_def = function(cohortId, label = NULL, category = NULL, tags = NULL, silent = FALSE) {
       checkmate::assert_int(cohortId)
 
       conn <- DBI::dbConnect(RSQLite::SQLite(), private$.dbPath)
@@ -780,7 +817,9 @@ CohortManifest <- R6::R6Class(
       # Refresh in-memory manifest
       private$load_manifest_from_db()
 
-      cli::cli_alert_success("Updated cohort {cohortId}")
+      if (!silent) {
+        cli::cli_alert_success("Updated cohort {cohortId}")
+      }
       invisible(NULL)
     }
   ),
@@ -1151,7 +1190,7 @@ CohortManifest <- R6::R6Class(
 
           existing <- DBI::dbGetQuery(
             conn,
-            "SELECT file_path, hash, cohort_type, tags FROM cohort_manifest WHERE id = ?",
+            "SELECT file_path, hash, cohort_type, category, tags FROM cohort_manifest WHERE id = ?",
             list(existing_id)
           )
 
@@ -1193,7 +1232,10 @@ CohortManifest <- R6::R6Class(
           # Refresh metadata (category, tags, atlasId) regardless of content change
           tags$route <- "atlas"
           tags$atlasId <- as.integer(atlasId)
-          private$update_cohort_def(cohortId = existing_id, category = category, tags = tags)
+          new_tags_json <- if (length(tags) > 0) jsonlite::toJSON(tags, auto_unbox = TRUE) else NA_character_
+          metadata_changed <- !identical(as.character(category), as.character(existing$category[1])) ||
+            !identical(as.character(new_tags_json), as.character(existing$tags[1]))
+          private$update_cohort_def(cohortId = existing_id, category = category, tags = tags, silent = TRUE)
 
           # Write to a temp file first so a failed write cannot clobber the
           # registered JSON, and unchanged definitions leave the file untouched
@@ -1201,10 +1243,15 @@ CohortManifest <- R6::R6Class(
           tmp_json <- tempfile(fileext = ".json")
           readr::write_lines(cohort_def$expression[1], tmp_json)
           new_hash <- rlang::hash(readr::read_file(tmp_json))
+          definition_changed <- !identical(new_hash, existing$hash[1])
 
-          if (identical(new_hash, existing$hash[1])) {
+          if (!definition_changed) {
             unlink(tmp_json)
-            cli::cli_alert_info("Cohort {existing_id}: {label} definition is unchanged")
+            if (metadata_changed) {
+              cli::cli_alert_info("Cohort {existing_id}: {label} — definition unchanged, metadata updated")
+            } else {
+              cli::cli_alert_info("Cohort {existing_id}: {label} — definition and metadata unchanged")
+            }
             return(invisible(existing_id))
           }
 
@@ -1226,7 +1273,11 @@ CohortManifest <- R6::R6Class(
           # Refresh in-memory manifest
           private$load_manifest_from_db()
 
-          cli::cli_alert_success("Updated ATLAS cohort {existing_id}: {label}")
+          if (metadata_changed) {
+            cli::cli_alert_success("Updated ATLAS cohort {existing_id}: {label} — definition and metadata updated")
+          } else {
+            cli::cli_alert_success("Updated ATLAS cohort {existing_id}: {label} — definition updated, metadata unchanged")
+          }
           return(invisible(existing_id))
         }
       }
@@ -1461,12 +1512,29 @@ CohortManifest <- R6::R6Class(
       if (!stopIfExists) {
         existing_id <- private$find_active_id_by_label(label)
         if (!is.na(existing_id)) {
+          conn <- DBI::dbConnect(RSQLite::SQLite(), private$.dbPath)
+          before <- DBI::dbGetQuery(
+            conn,
+            "SELECT category, tags FROM cohort_manifest WHERE id = ?",
+            list(existing_id)
+          )
+          DBI::dbDisconnect(conn)
+
           cli::cli_alert_info("Cohort {.val {label}} already exists (ID {existing_id}) — updating in place")
+          # updateCaprCohort() reports whether the JSON definition itself changed
           self$updateCaprCohort(caprCohort, label = label)
+
           # Replace metadata wholesale (matching addAtlasCohort): tags not
           # re-supplied here are dropped, keeping only the route provenance
           tags$route <- "capr"
-          private$update_cohort_def(cohortId = existing_id, category = category, tags = tags)
+          new_tags_json <- if (length(tags) > 0) jsonlite::toJSON(tags, auto_unbox = TRUE) else NA_character_
+          metadata_changed <- !identical(as.character(category), as.character(before$category[1])) ||
+            !identical(as.character(new_tags_json), as.character(before$tags[1]))
+          private$update_cohort_def(cohortId = existing_id, category = category, tags = tags, silent = TRUE)
+
+          if (metadata_changed) {
+            cli::cli_alert_info("Cohort {existing_id}: {label} — metadata updated (category/tags)")
+          }
           return(invisible(existing_id))
         }
       }
@@ -1624,7 +1692,7 @@ CohortManifest <- R6::R6Class(
     #'
     #' @return Invisible integer. The assigned cohort ID.
     addSqlCohort = function(filePath, label, category, tags = list(), stopIfExists = TRUE) {
-      cohort_id <- private$register_custom_sql_cohort(
+      result <- private$register_custom_sql_cohort(
         filePath = filePath,
         label = label,
         category = category,
@@ -1633,8 +1701,12 @@ CohortManifest <- R6::R6Class(
         dependentCohortIdList = NULL
       )
 
-      cli::cli_alert_success("Added SQL cohort {cohort_id}: {label}")
-      invisible(cohort_id)
+      # On update, register_custom_sql_cohort() already reported whether the
+      # definition and/or metadata changed
+      if (result$isNew) {
+        cli::cli_alert_success("Added SQL cohort {result$id}: {label}")
+      }
+      invisible(result$id)
     },
 
     #' @description Add a dependent custom SQL cohort
@@ -1662,7 +1734,7 @@ CohortManifest <- R6::R6Class(
     #'
     #' @return Invisible integer. The assigned cohort ID.
     addDependentCustomCohort = function(filePath, label, category, dependentCohortIdList, tags = list(), stopIfExists = TRUE) {
-      cohort_id <- private$register_custom_sql_cohort(
+      result <- private$register_custom_sql_cohort(
         filePath = filePath,
         label = label,
         category = category,
@@ -1671,8 +1743,12 @@ CohortManifest <- R6::R6Class(
         dependentCohortIdList = dependentCohortIdList
       )
 
-      cli::cli_alert_success("Added dependent custom cohort {cohort_id}: {label}")
-      invisible(cohort_id)
+      # On update, upsert_derived_cohort() already reported whether the
+      # definition and/or metadata changed
+      if (result$isNew) {
+        cli::cli_alert_success("Added dependent custom cohort {result$id}: {label}")
+      }
+      invisible(result$id)
     },
 
     #' @description Add a Circe JSON cohort from disk

--- a/R/CohortManifest.R
+++ b/R/CohortManifest.R
@@ -1288,18 +1288,25 @@ CohortManifest <- R6::R6Class(
     #' Either create a dataframe or read in a csv file with columns `atlasId`, `label`, `category` (required) plus any
     #' additional columns treated as tag key-value pairs for tags. Calls `addAtlasCohort()` for each row.
     #'
-    #' The load file is a transient, one-time import mechanism: rows whose
-    #' atlasId or label are already registered in the manifest are an error, not
-    #' an update. To sync registered cohorts with ATLAS, run
-    #' `updateAtlasCohorts()`; to update a single cohort, use
-    #' `addAtlasCohort(stopIfExists = FALSE)`.
+    #' By default, the load file is treated as a transient, one-time import
+    #' mechanism: rows whose atlasId is already registered in the manifest are
+    #' an error, not an update. Set `stopIfExists = FALSE` to instead update
+    #' those rows in place (delegates to `addAtlasCohort(stopIfExists = FALSE)`
+    #' for each), which supports iterating on the load file across repeated
+    #' runs. To sync registered cohorts with ATLAS without a load file, use
+    #' `updateAtlasCohorts()`.
     #'
     #' @param cohortsLoad a data frame requiring the columns atlasId, label and category used to bulk add cohorts to the manifest
     #' @param atlasConnection An ATLAS connection object with a `getCohortDefinition(cohortId)` method.
     #'   If `NULL`, falls back to the connection stored via `$setAtlasConnection()`.
+    #' @param stopIfExists Logical. If TRUE (default), raises an error when any
+    #'   load row's atlasId is already registered in the manifest. If FALSE,
+    #'   those rows are updated in place instead (same ID/file path, hash
+    #'   refreshed, category/tags replaced) via `addAtlasCohort(stopIfExists = FALSE)`.
+    #'   Default: TRUE (fail-safe).
     #'
     #' @return Invisible tibble of imported cohorts.
-    importAtlasCohorts = function(cohortsLoad, atlasConnection = NULL) {
+    importAtlasCohorts = function(cohortsLoad, atlasConnection = NULL, stopIfExists = TRUE) {
       if (is.null(atlasConnection)) {
         atlasConnection <- private$.atlasConnection
       }
@@ -1311,6 +1318,7 @@ CohortManifest <- R6::R6Class(
         ))
       }
 
+      checkmate::assert_flag(stopIfExists)
 
       # Validate required columns
       required_cols <- c("atlasId", "label", "category")
@@ -1335,9 +1343,10 @@ CohortManifest <- R6::R6Class(
       existing_cohorts <- cohort_load_2 |>
         dplyr::filter(status == "active")
 
-      # The load csv is a transient, one-time import file — registered rows are
-      # an error, not an update mechanism. Fail fast before importing anything.
-      if (nrow(existing_cohorts) > 0) {
+      # By default, the load csv is a transient, one-time import file —
+      # registered rows are an error, not an update mechanism. Fail fast
+      # before importing anything, unless the caller opted into upserting.
+      if (stopIfExists && nrow(existing_cohorts) > 0) {
         offending <- paste0(
           "[", existing_cohorts$id, "] ", existing_cohorts$label,
           " (atlasId ", existing_cohorts$atlasId, ")"
@@ -1345,9 +1354,8 @@ CohortManifest <- R6::R6Class(
         cli::cli_abort(c(
           "{nrow(existing_cohorts)} cohort(s) in the load file are already registered in the manifest:",
           stats::setNames(offending, rep("x", length(offending))),
-          i = "Remove them from the load csv — it is for one-time imports only.",
-          i = "To sync registered cohorts with ATLAS, run {.code updateAtlasCohorts()}.",
-          i = "To update a single cohort, use {.code addAtlasCohort(stopIfExists = FALSE)}."
+          i = "Remove them from the load csv, or re-run with {.code stopIfExists = FALSE} to update them in place.",
+          i = "To sync registered cohorts with ATLAS, run {.code updateAtlasCohorts()}."
         ))
       }
 
@@ -1379,11 +1387,30 @@ CohortManifest <- R6::R6Class(
         }
       }
 
+      # Update existing cohorts in place (stopIfExists = FALSE only)
+      if (!stopIfExists && nrow(existing_cohorts) > 0) {
+        cli::cli_rule("Updating {nrow(existing_cohorts)} existing cohort(s)")
+        for (i in seq_len(nrow(existing_cohorts))) {
+          row <- existing_cohorts[i, ]
+          additional_tags <- list_tags_in_row(row)
+          # Delegate to addAtlasCohort's upsert path for the in-place update
+          cohort_id <- self$addAtlasCohort(
+            atlasId = row$atlasId,
+            label = row$label,
+            category = row$category,
+            tags = additional_tags,
+            atlasConnection = atlasConnection,
+            stopIfExists = FALSE
+          )
+        }
+      }
+
       # Build and print final summary table
       summary_tbl <- cohort_load_2 |>
         dplyr::mutate(
           message = dplyr::case_when(
             status == "new" ~ "Successfully added to manifest",
+            status == "active" & !stopIfExists ~ "Updated in manifest",
             TRUE ~ "Unknown"
           )
         ) |>

--- a/R/CohortManifest.R
+++ b/R/CohortManifest.R
@@ -483,13 +483,15 @@ CohortManifest <- R6::R6Class(
     },
 
     register_custom_sql_cohort = function(filePath, label, category, tags = list(),
-                                          stopIfExists = TRUE, dependentCohortIdList = NULL) {
+                                          stopIfExists = TRUE, dependentCohortIdList = NULL,
+                                          sqlParameters = list()) {
       checkmate::assert_file_exists(filePath)
       checkmate::assert_string(label, min.chars = 1)
       checkmate::assert_string(category, min.chars = 1)
       checkmate::assert_list(tags, names = "named")
       checkmate::assert_flag(stopIfExists)
       checkmate::assert_list(dependentCohortIdList, null.ok = TRUE)
+      checkmate::assert_list(sqlParameters, names = "named")
 
       is_dependent <- !is.null(dependentCohortIdList)
 
@@ -500,17 +502,66 @@ CohortManifest <- R6::R6Class(
 
         dep_names <- names(dependentCohortIdList)
         if (is.null(dep_names) || any(is.na(dep_names)) || any(trimws(dep_names) == "")) {
-          cli::cli_abort("dependentCohortIdList must be a named list of SqlRender parameter names to cohort IDs")
+          cli::cli_abort(c(
+            "dependentCohortIdList must be a named list of SqlRender parameter names to cohort IDs or manifest entries.",
+            i = "Each value can be an integer cohort ID (or vector of IDs), or a data.frame/tibble with an {.field id} column (e.g. from {.code queryCohortsByLabel()})."
+          ))
         }
 
         if (!all(lengths(dependentCohortIdList) >= 1L)) {
           cli::cli_abort("Each dependentCohortIdList entry must contain at least one cohort ID")
         }
 
+        # Each entry can be given either as the legacy integer ID route, or as
+        # a manifest entry (data.frame/tibble with an id column) like the
+        # other derived cohort builders - a single row resolves to one ID, a
+        # multi-row table resolves to a vector (for IN (@param) clauses).
+        # Labels are captured (when available) purely for the QC header below.
+        resolved_ids <- list()
+        resolved_labels <- list()
+        for (dep_name in dep_names) {
+          dep_value <- dependentCohortIdList[[dep_name]]
+          if (is.data.frame(dep_value)) {
+            if (nrow(dep_value) == 0) {
+              cli::cli_abort("dependentCohortIdList entry {.val {dep_name}} is an empty manifest entry table.")
+            } else if (nrow(dep_value) == 1) {
+              resolved_ids[[dep_name]] <- private$resolve_single_entry_id(dep_value, dep_name)
+            } else {
+              resolved_ids[[dep_name]] <- private$resolve_multi_entry_ids(dep_value, dep_name)
+            }
+            resolved_labels[[dep_name]] <- if ("label" %in% names(dep_value)) as.character(dep_value$label) else NA_character_
+          } else {
+            checkmate::assert_integerish(dep_value, min.len = 1, any.missing = FALSE, .var.name = dep_name)
+            resolved_ids[[dep_name]] <- as.integer(dep_value)
+            resolved_labels[[dep_name]] <- NA_character_
+          }
+        }
+        dependentCohortIdList <- resolved_ids
+
         # Entries may hold a single cohort ID or a vector of IDs (rendered
         # comma-separated by SqlRender, e.g. for IN (@param) clauses)
         dependent_ids <- unlist(dependentCohortIdList, use.names = TRUE)
         checkmate::assert_integerish(x = dependent_ids, min.len = 1, any.missing = FALSE, unique = TRUE)
+
+        sql_param_names <- names(sqlParameters)
+        if (length(sqlParameters) > 0 &&
+              (is.null(sql_param_names) || any(is.na(sql_param_names)) || any(trimws(sql_param_names) == ""))) {
+          cli::cli_abort("sqlParameters must be a named list of SqlRender parameter names to values")
+        }
+
+        overlap <- intersect(dep_names, sql_param_names)
+        if (length(overlap) > 0) {
+          cli::cli_abort("dependentCohortIdList and sqlParameters cannot share parameter name(s): {paste(overlap, collapse = ', ')}")
+        }
+
+        reserved_names <- custom_derived_reserved_param_names()
+        colliding_names <- intersect(c(dep_names, sql_param_names), reserved_names)
+        if (length(colliding_names) > 0) {
+          cli::cli_abort(c(
+            "dependentCohortIdList/sqlParameters use reserved SqlRender parameter name(s).",
+            i = "Reserved names: {paste(colliding_names, collapse = ', ')}"
+          ))
+        }
       }
 
       ext <- tolower(tools::file_ext(filePath))
@@ -552,24 +603,26 @@ CohortManifest <- R6::R6Class(
         cli::cli_alert_info("Cohort {.val {label}} already exists (ID {existing_id}) — updating in place")
       }
 
-      existing_cohort <- DBI::dbGetQuery(
-        conn,
-        "SELECT id FROM cohort_manifest WHERE file_path = ? AND status = 'active'",
-        list(rel_path)
-      )
+      if (!is_dependent) {
+        existing_cohort <- DBI::dbGetQuery(
+          conn,
+          "SELECT id FROM cohort_manifest WHERE file_path = ? AND status = 'active'",
+          list(rel_path)
+        )
 
-      # A file-path conflict with the upsert target itself is not a conflict
-      is_self <- nrow(existing_cohort) > 0 && !is.na(existing_id) &&
-        as.integer(existing_cohort$id[1]) == existing_id
+        # A file-path conflict with the upsert target itself is not a conflict
+        is_self <- nrow(existing_cohort) > 0 && !is.na(existing_id) &&
+          as.integer(existing_cohort$id[1]) == existing_id
 
-      if (nrow(existing_cohort) > 0 && !is_self) {
-        if (isTRUE(stopIfExists)) {
-          cli::cli_abort(c(
-            "File path already registered in manifest (cohort {existing_cohort$id[1]})",
-            i = "Set {.arg stopIfExists = FALSE} to replace registration"
-          ))
-        } else {
-          cli::cli_warn("Replacing existing manifest entry for {.file {rel_path}}")
+        if (nrow(existing_cohort) > 0 && !is_self) {
+          if (isTRUE(stopIfExists)) {
+            cli::cli_abort(c(
+              "File path already registered in manifest (cohort {existing_cohort$id[1]})",
+              i = "Set {.arg stopIfExists = FALSE} to replace registration"
+            ))
+          } else {
+            cli::cli_warn("Replacing existing manifest entry for {.file {rel_path}}")
+          }
         }
       }
 
@@ -600,16 +653,29 @@ CohortManifest <- R6::R6Class(
           ))
         }
 
+        # Bake the dependent cohort IDs and any extra sqlParameters directly
+        # into a generated derived-cohort file (like the other derived cohort
+        # types), leaving the connection/schema placeholders unrendered for
+        # generateCohorts() to fill in at execution time.
+        derived_dir <- make_derived_folder(dirname(private$.dbPath))
+        render_params <- c(dependentCohortIdList, sqlParameters)
+        header <- format_dependent_cohort_header(resolved_ids = dependentCohortIdList, resolved_labels = resolved_labels)
+        sql_path <- do.call(
+          render_and_write_derived_sql,
+          c(list(derived_dir = derived_dir, label = label, sql_content = sql_content, header = header), render_params)
+        )
+
         cohort_id <- private$upsert_derived_cohort(
           existingId = existing_id,
           label = label,
           category = category,
           tags = tags,
-          file_path = rel_path,
+          file_path = fs::path_rel(sql_path),
           cohort_type = "custom_derived",
           depends_on = as.integer(unname(dependent_ids)),
           dependency_rule = list(
-            dependentCohortIdList = as.list(dependentCohortIdList) # use a named list
+            dependentCohortIdList = as.list(dependentCohortIdList),
+            sqlParameters = if (length(sqlParameters) > 0) as.list(sqlParameters) else NULL
           ),
           source_type = "sql"
         )
@@ -969,7 +1035,7 @@ CohortManifest <- R6::R6Class(
           ),
           custom_derived = {
             dep_map <- rule$dependentCohortIdList
-            if (is.null(dep_map) || length(dep_map) == 0) {
+            dep_part <- if (is.null(dep_map) || length(dep_map) == 0) {
               ""
             } else {
               dep_values <- unlist(dep_map, use.names = TRUE)
@@ -983,6 +1049,18 @@ CohortManifest <- R6::R6Class(
               }, names(dep_values), dep_values, USE.NAMES = FALSE)
               paste(parts, collapse = " | ")
             }
+
+            sql_params <- rule$sqlParameters
+            param_part <- if (is.null(sql_params) || length(sql_params) == 0) {
+              ""
+            } else {
+              parts <- mapply(function(param_name, value) {
+                paste0(param_name, "=", paste(unlist(value), collapse = ","))
+              }, names(sql_params), sql_params, USE.NAMES = FALSE)
+              paste(parts, collapse = " | ")
+            }
+
+            paste(c(dep_part, param_part)[c(dep_part, param_part) != ""], collapse = " | ")
           },
           ""
         )
@@ -1711,36 +1789,54 @@ CohortManifest <- R6::R6Class(
 
     #' @description Add a dependent custom SQL cohort
     #'
-    #' Registers an existing SQL file in the manifest as a dependency-aware derived cohort.
-    #' The SQL file must already exist on disk and must preserve the standard Picard
-    #' cohort write contract using \.code{@target_database_schema.@target_cohort_table}
-    #' and \.code{@target_cohort_id}.
+    #' Registers a SQL file in the manifest as a dependency-aware derived cohort.
+    #' The source SQL file must preserve the standard Picard cohort write contract
+    #' using \.code{@target_database_schema.@target_cohort_table} and
+    #' \.code{@target_cohort_id}.
     #'
-    #' @param filePath Character. Path to the SQL file.
+    #' `dependentCohortIdList` and `sqlParameters` values are rendered into the
+    #' source SQL immediately (via \.code{SqlRender::render()}) and the result is
+    #' written to \.code{inputs/cohorts/derived/<label>.sql} — the file registered
+    #' in the manifest — exactly like the built-in derived cohort types (subset,
+    #' union, etc.). Only the connection/schema placeholders (\.code{@target_cohort_id}
+    #' and friends) are left for \.code{generateCohorts()} to fill in at execution time.
+    #'
+    #' @param filePath Character. Path to the source SQL file/template.
     #' @param label Character. Display name for the cohort.
     #' @param category Character. Required classification.
-    #' @param dependentCohortIdList Named list. Each name is a SqlRender parameter to expose
-    #'   in the SQL file and each value is the cohort ID — or an integer vector of
-    #'   cohort IDs — to inject at runtime. Vectors render comma-separated, for use
-    #'   in \.code{IN (@param)} clauses.
-    #'   Example: \.code{list(inc_cohort_id = 10L, exc_cohort_ids = c(12L, 14L))}.
+    #' @param dependentCohortIdList Named list. Each name is a SqlRender parameter to
+    #'   render into the SQL file. Each value is, preferably, a manifest entry —
+    #'   a data.frame/tibble with an \.code{id} column, as returned by query methods
+    #'   like \.code{queryCohortsByLabel()} (a single row bakes in one ID; a multi-row
+    #'   table bakes in a comma-separated vector, for \.code{IN (@param)} clauses) —
+    #'   or, for backward compatibility, a raw integer cohort ID (or integer vector).
+    #'   These IDs also become this cohort's \.code{depends_on} parents for staleness
+    #'   tracking. When entries carry a \.code{label} column, it's included (purely
+    #'   for QC) in a generated comment header at the top of the derived SQL file.
+    #'   Example: \.code{list(inc_cohort_id = ckdEntry, exc_cohort_id = t2dEntry)}.
+    #' @param sqlParameters Named list. Optional additional SqlRender parameters to
+    #'   render into the SQL file (any type — thresholds, dates, strings, etc.),
+    #'   not treated as cohort dependencies.
+    #'   Example: \.code{list(min_days = 30L, index_year = 2020L)}.
     #' @param tags Named list. Optional metadata tags.
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered cohort in place (same ID): the dependent cohort
-    #'   IDs and the SQL file registration (path and content hash) are replaced,
-    #'   the cohort is marked 'stale' for regeneration, and its own dependents
-    #'   are marked stale too. Default: TRUE (fail-safe).
+    #'   IDs/sqlParameters are re-rendered into the generated file, the cohort is
+    #'   marked 'stale' for regeneration, and its own dependents are marked stale
+    #'   too. Default: TRUE (fail-safe).
     #'
     #' @return Invisible integer. The assigned cohort ID.
-    addDependentCustomCohort = function(filePath, label, category, dependentCohortIdList, tags = list(), stopIfExists = TRUE) {
+    addDependentCustomCohort = function(filePath, label, category, dependentCohortIdList,
+                                        sqlParameters = list(), tags = list(), stopIfExists = TRUE) {
       result <- private$register_custom_sql_cohort(
         filePath = filePath,
         label = label,
         category = category,
         tags = tags,
         stopIfExists = stopIfExists,
-        dependentCohortIdList = dependentCohortIdList
+        dependentCohortIdList = dependentCohortIdList,
+        sqlParameters = sqlParameters
       )
 
       # On update, upsert_derived_cohort() already reported whether the

--- a/R/ConceptSetManifest.R
+++ b/R/ConceptSetManifest.R
@@ -906,17 +906,24 @@ ConceptSetManifest <- R6::R6Class(
     #' @param atlasConnection An ATLAS connection object with a
     #'   `getConceptSetDefinition(conceptSetId)` method.
     #'   If `NULL`, falls back to the connection stored via `$setAtlasConnection()`.
+    #' @param stopIfExists Logical. If TRUE (default), raises an error when any
+    #'   load row's atlasId is already registered in the manifest. If FALSE,
+    #'   those rows are updated in place instead (same ID/file path, hash
+    #'   refreshed, category/tags replaced) via `addAtlasConceptSet(stopIfExists = FALSE)`.
+    #'   Default: TRUE (fail-safe).
     #'
     #' @details
-    #' The load file is a transient, one-time import mechanism: rows whose
-    #' atlasId or label are already registered in the manifest are an error, not
-    #' an update. To sync registered concept sets with ATLAS, run
-    #' `updateAtlasConceptSets()`; to update a single concept set, use
-    #' `addAtlasConceptSet(stopIfExists = FALSE)`.
+    #' By default, the load file is treated as a transient, one-time import
+    #' mechanism: rows whose atlasId is already registered in the manifest are
+    #' an error, not an update. Set `stopIfExists = FALSE` to instead update
+    #' those rows in place, which supports iterating on the load file across
+    #' repeated runs. To sync registered concept sets with ATLAS without a
+    #' load file, use `updateAtlasConceptSets()`.
     #'
     #' @return Invisible tibble imported concept sets.
     importAtlasConceptSets = function(conceptSetsLoad,
-                                      atlasConnection = NULL) {
+                                      atlasConnection = NULL,
+                                      stopIfExists = TRUE) {
       if (is.null(atlasConnection)) {
         atlasConnection <- private$.atlasConnection
       }
@@ -927,6 +934,8 @@ ConceptSetManifest <- R6::R6Class(
           i = "Supply {.arg atlasConnection} or call {.code $setAtlasConnection()} first."
         ))
       }
+
+      checkmate::assert_flag(stopIfExists)
 
       # Validate required columns
       required_cols <- c("atlasId", "label", "category")
@@ -952,9 +961,10 @@ ConceptSetManifest <- R6::R6Class(
       existing_concept_sets <- concept_set_load_2 |>
         dplyr::filter(status == "active")
 
-      # The load csv is a transient, one-time import file — registered rows are
-      # an error, not an update mechanism. Fail fast before importing anything.
-      if (nrow(existing_concept_sets) > 0) {
+      # By default, the load csv is a transient, one-time import file —
+      # registered rows are an error, not an update mechanism. Fail fast
+      # before importing anything, unless the caller opted into upserting.
+      if (stopIfExists && nrow(existing_concept_sets) > 0) {
         offending <- paste0(
           "[", existing_concept_sets$id, "] ", existing_concept_sets$label,
           " (atlasId ", existing_concept_sets$atlasId, ")"
@@ -962,9 +972,8 @@ ConceptSetManifest <- R6::R6Class(
         cli::cli_abort(c(
           "{nrow(existing_concept_sets)} concept set(s) in the load file are already registered in the manifest:",
           stats::setNames(offending, rep("x", length(offending))),
-          i = "Remove them from the load csv — it is for one-time imports only.",
-          i = "To sync registered concept sets with ATLAS, run {.code updateAtlasConceptSets()}.",
-          i = "To update a single concept set, use {.code addAtlasConceptSet(stopIfExists = FALSE)}."
+          i = "Remove them from the load csv, or re-run with {.code stopIfExists = FALSE} to update them in place.",
+          i = "To sync registered concept sets with ATLAS, run {.code updateAtlasConceptSets()}."
         ))
       }
 
@@ -996,11 +1005,30 @@ ConceptSetManifest <- R6::R6Class(
         }
       }
 
+      # Update existing concept sets in place (stopIfExists = FALSE only)
+      if (!stopIfExists && nrow(existing_concept_sets) > 0) {
+        cli::cli_rule("Updating {nrow(existing_concept_sets)} existing concept set(s)")
+        for (i in seq_len(nrow(existing_concept_sets))) {
+          row <- existing_concept_sets[i, ]
+          additional_tags <- list_tags_in_row(row)
+          # Delegate to addAtlasConceptSet's upsert path for the in-place update
+          concept_set_id <- self$addAtlasConceptSet(
+            atlasId = row$atlasId,
+            label = row$label,
+            category = ifelse(is.na(row$category), "None", row$category),
+            tags = additional_tags,
+            atlasConnection = atlasConnection,
+            stopIfExists = FALSE
+          )
+        }
+      }
+
       # Build and print final summary table
       summary_tbl <- concept_set_load_2 |>
         dplyr::mutate(
           message = dplyr::case_when(
             status == "new" ~ "Successfully added to manifest",
+            status == "active" & !stopIfExists ~ "Updated in manifest",
             TRUE ~ "Unknown"
           )
         ) |>

--- a/R/ConceptSetManifest.R
+++ b/R/ConceptSetManifest.R
@@ -357,7 +357,7 @@ ConceptSetManifest <- R6::R6Class(
     },
 
     # Update concept set metadata (label, category, tags)
-    update_concept_set_def = function(conceptSetId, label = NULL, category = NULL, tags = NULL) {
+    update_concept_set_def = function(conceptSetId, label = NULL, category = NULL, tags = NULL, silent = FALSE) {
       checkmate::assert_int(conceptSetId)
 
       conn <- DBI::dbConnect(RSQLite::SQLite(), private$.dbPath)
@@ -428,7 +428,9 @@ ConceptSetManifest <- R6::R6Class(
       # Refresh in-memory manifest
       private$load_manifest_from_db()
 
-      cli::cli_alert_success("Updated concept set {conceptSetId}")
+      if (!silent) {
+        cli::cli_alert_success("Updated concept set {conceptSetId}")
+      }
       invisible(NULL)
     }
   ),
@@ -627,7 +629,7 @@ ConceptSetManifest <- R6::R6Class(
 
         existing <- DBI::dbGetQuery(
           conn,
-          "SELECT file_path, hash, tags FROM concept_set_manifest WHERE id = ?",
+          "SELECT file_path, hash, category, tags FROM concept_set_manifest WHERE id = ?",
           list(existing_id)
         )
 
@@ -659,7 +661,10 @@ ConceptSetManifest <- R6::R6Class(
         )
 
         # Refresh metadata regardless of content change
-        private$update_concept_set_def(conceptSetId = existing_id, category = category, tags = tags)
+        new_tags_json <- if (length(tags) > 0) jsonlite::toJSON(tags, auto_unbox = TRUE) else NA_character_
+        metadata_changed <- !identical(as.character(category), as.character(existing$category[1])) ||
+          !identical(as.character(new_tags_json), as.character(existing$tags[1]))
+        private$update_concept_set_def(conceptSetId = existing_id, category = category, tags = tags, silent = TRUE)
 
         # Write to a temp file first so a failed write cannot clobber the
         # registered JSON, and unchanged definitions leave the file untouched
@@ -667,10 +672,15 @@ ConceptSetManifest <- R6::R6Class(
         tmp_json <- tempfile(fileext = ".json")
         readr::write_lines(cs_def$expression[1], tmp_json)
         new_hash <- rlang::hash(readr::read_file(tmp_json))
+        definition_changed <- !identical(new_hash, existing$hash[1])
 
-        if (identical(new_hash, existing$hash[1])) {
+        if (!definition_changed) {
           unlink(tmp_json)
-          cli::cli_alert_info("Concept set {existing_id}: {label} definition is unchanged")
+          if (metadata_changed) {
+            cli::cli_alert_info("Concept set {existing_id}: {label} — definition unchanged, metadata updated")
+          } else {
+            cli::cli_alert_info("Concept set {existing_id}: {label} — definition and metadata unchanged")
+          }
           return(invisible(existing_id))
         }
 
@@ -688,7 +698,11 @@ ConceptSetManifest <- R6::R6Class(
 
         private$load_manifest_from_db()
 
-        cli::cli_alert_success("Updated ATLAS concept set {existing_id}: {label}")
+        if (metadata_changed) {
+          cli::cli_alert_success("Updated ATLAS concept set {existing_id}: {label} — definition and metadata updated")
+        } else {
+          cli::cli_alert_success("Updated ATLAS concept set {existing_id}: {label} — definition updated, metadata unchanged")
+        }
         return(invisible(existing_id))
       }
 
@@ -771,13 +785,30 @@ ConceptSetManifest <- R6::R6Class(
         if (stopIfExists) {
           cli::cli_abort("Label '{label}' is already in use by concept set {existing_id}")
         }
+
+        conn <- DBI::dbConnect(RSQLite::SQLite(), private$.dbPath)
+        before <- DBI::dbGetQuery(
+          conn,
+          "SELECT category, tags FROM concept_set_manifest WHERE id = ?",
+          list(existing_id)
+        )
+        DBI::dbDisconnect(conn)
+
         # Upsert path: update the existing concept set in place
         cli::cli_alert_info("Concept set {.val {label}} already exists (ID {existing_id}) — updating in place")
+        # updateCaprConceptSet() reports whether the JSON definition itself changed
         self$updateCaprConceptSet(caprConceptSet, label = label)
 
         # Replace metadata wholesale (matching addAtlasConceptSet): tags not
         # re-supplied here are dropped
-        private$update_concept_set_def(conceptSetId = existing_id, category = category, tags = tags)
+        new_tags_json <- if (length(tags) > 0) jsonlite::toJSON(tags, auto_unbox = TRUE) else NA_character_
+        metadata_changed <- !identical(as.character(category), as.character(before$category[1])) ||
+          !identical(as.character(new_tags_json), as.character(before$tags[1]))
+        private$update_concept_set_def(conceptSetId = existing_id, category = category, tags = tags, silent = TRUE)
+
+        if (metadata_changed) {
+          cli::cli_alert_info("Concept set {existing_id}: {label} — metadata updated (category/tags)")
+        }
         return(invisible(existing_id))
       }
 

--- a/R/cohort_builders.R
+++ b/R/cohort_builders.R
@@ -1,11 +1,60 @@
-write_derived_template <- function(derived_dir, label, template_name, ...) {
+# Render a derived cohort's SQL with build-time parameters and write it to
+# inputs/cohorts/derived/<label>.sql. Parameters not passed in `...` (e.g. the
+# connection/schema placeholders filled in at generation time) are left as
+# literal @tokens in the output. `header`, when supplied, is prepended
+# verbatim (after rendering) as a QC comment block - not itself rendered.
+render_and_write_derived_sql <- function(derived_dir, label, sql_content, ..., header = NULL) {
     safe_label <- gsub("[^a-zA-Z0-9_-]", "_", label)
     sql_path <- fs::path(derived_dir, paste0(safe_label, ".sql"))
-    template_path <- system.file("sql", template_name, package = "picard")
-    rendered_sql <- readr::read_file(template_path) |>
-        SqlRender::render(...)
+    rendered_sql <- SqlRender::render(sql_content, ...)
+    if (!is.null(header) && length(header) > 0) {
+      rendered_sql <- paste(c(header, "", rendered_sql), collapse = "\n")
+    }
     writeLines(rendered_sql, sql_path)
     return(sql_path)
+}
+
+write_derived_template <- function(derived_dir, label, template_name, ...) {
+    template_path <- system.file("sql", template_name, package = "picard")
+    sql_content <- readr::read_file(template_path)
+    render_and_write_derived_sql(derived_dir, label, sql_content, ...)
+}
+
+# Build a "/* Dependent cohorts ... */" QC header documenting which cohort
+# (id and, when known, label) was baked into each named SqlRender parameter.
+format_dependent_cohort_header <- function(resolved_ids, resolved_labels) {
+  lines <- mapply(function(param_name, ids, labels) {
+    id_str <- paste(ids, collapse = ",")
+    known_labels <- if (is.null(labels)) character(0) else labels[!is.na(labels)]
+    label_part <- if (length(known_labels) > 0) paste0(", label ", paste(known_labels, collapse = "; ")) else ""
+    paste0("  ", param_name, ": id ", id_str, label_part)
+  }, names(resolved_ids), resolved_ids, resolved_labels, SIMPLIFY = TRUE, USE.NAMES = FALSE)
+
+  c("/*", "Dependent cohorts (baked in at registration time)", lines, "*/")
+}
+
+# SqlRender parameter names reserved for the generation-time connection/schema
+# context (see generate_single_cohort()) - user-supplied dependentCohortIdList
+# or sqlParameters names must not collide with these.
+custom_derived_reserved_param_names <- function() {
+  c(
+    "sql",
+    "header",
+    "cdm_database_schema",
+    "vocabulary_database_schema",
+    "target_database_schema",
+    "target_cohort_table",
+    "target_cohort_id",
+    "output_cohort_id",
+    "output_table",
+    "base_cohort_table",
+    "results_database_schema.cohort_inclusion",
+    "results_database_schema.cohort_inclusion_result",
+    "results_database_schema.cohort_inclusion_stats",
+    "results_database_schema.cohort_summary_stats",
+    "results_database_schema.cohort_censor_stats",
+    "warnOnMissingParameters"
+  )
 }
 
 make_derived_folder <- function(cohorts_dir) {
@@ -339,71 +388,6 @@ evaluate_cohort_skip_status <- function(
   return(skip_status)
 }
 
-get_custom_derived_sql_params <- function(sqlite_conn, cohort_id) {
-  dep_row <- DBI::dbGetQuery(
-    sqlite_conn,
-    "SELECT dependency_rule FROM cohort_manifest WHERE id = ? AND status IN ('active', 'stale')",
-    list(cohort_id)
-  )
-
-  if (nrow(dep_row) == 0 || is.na(dep_row$dependency_rule[1]) || nchar(dep_row$dependency_rule[1]) == 0) {
-    cli::cli_abort("custom_derived cohort {cohort_id} is missing dependency_rule metadata")
-  }
-
-  dep_rule <- tryCatch(
-    jsonlite::fromJSON(dep_row$dependency_rule[1], simplifyVector = FALSE),
-    error = function(e) {
-      cli::cli_abort("Failed to parse dependency_rule for custom_derived cohort {cohort_id}: {e$message}")
-    }
-  )
-
-  custom_params <- dep_rule$dependentCohortIdList
-  # Vector-valued entries come back from JSON as lists; flatten each to an
-  # atomic vector so SqlRender renders them comma-separated (IN clauses)
-  custom_params <- lapply(custom_params, function(x) unlist(x, use.names = FALSE))
-  if (is.null(custom_params) || length(custom_params) == 0) {
-    cli::cli_abort("custom_derived cohort {cohort_id} is missing dependentCohortIdList metadata")
-  }
-
-  param_names <- names(custom_params)
-  if (is.null(param_names) || any(is.na(param_names)) || any(trimws(param_names) == "")) {
-    cli::cli_abort("custom_derived cohort {cohort_id} has unnamed dependent SqlRender parameters")
-  }
-
-  reserved_names <- c(
-    "sql",
-    "cdm_database_schema",
-    "vocabulary_database_schema",
-    "target_database_schema",
-    "target_cohort_table",
-    "target_cohort_id",
-    "output_cohort_id",
-    "output_table",
-    "base_cohort_table",
-    "results_database_schema.cohort_inclusion",
-    "results_database_schema.cohort_inclusion_result",
-    "results_database_schema.cohort_inclusion_stats",
-    "results_database_schema.cohort_summary_stats",
-    "results_database_schema.cohort_censor_stats",
-    "warnOnMissingParameters"
-  )
-
-  colliding_names <- intersect(param_names, reserved_names)
-  if (length(colliding_names) > 0) {
-    cli::cli_abort(c(
-      "custom_derived cohort {cohort_id} uses reserved SqlRender parameter name(s).",
-      i = "Reserved names: {paste(colliding_names, collapse = ', ')}"
-    ))
-  }
-
-  custom_params <- lapply(custom_params, function(value) {
-    as.integer(value)
-  })
-
-  return(custom_params)
-}
-
-
 generate_single_cohort <- function(
     cohort, 
     cohort_id, 
@@ -448,11 +432,6 @@ generate_single_cohort <- function(
     sql_params$output_cohort_id <- cohort_id
     sql_params$output_table <- output_table_name
     sql_params$base_cohort_table <- output_table_name
-  }
-
-  if (cohort_type == "custom_derived") {
-    custom_sql_params <- get_custom_derived_sql_params(sqlite_conn, cohort_id)
-    sql_params <- c(sql_params, custom_sql_params)
   }
 
   render_result <- try(do.call(SqlRender::render, c(list(sql = cohort_sql), sql_params)), silent = TRUE)

--- a/inst/agent/04-loading-inputs.md
+++ b/inst/agent/04-loading-inputs.md
@@ -555,22 +555,33 @@ for comprehensive examples of all derived cohort types.
 Use this pattern when a custom SQL cohort depends on one or more previously
 defined cohorts (for example inclusion/exclusion cohorts). This registers the
 cohort as a dependency-aware derived type (`custom_derived`) so execution order,
-stale detection, and dependency hashing are handled automatically. 
+stale detection, and dependency hashing are handled automatically.
+
+Like the built-in derived cohort builders (subset, union, etc.), the values you
+supply are rendered into the SQL immediately and the rendered file is written to
+`inputs/cohorts/derived/<label>.sql` — that generated file, not your source file,
+is what's registered in the manifest. Only the connection/schema placeholders
+(`@target_cohort_id` and friends) are left unrendered, for `generateCohorts()`
+to fill in at execution time.
 
 ```{r}
 cohortManifest <- loadCohortManifest()
 
-# Example dependencies already in the manifest:
-# - 1001 = Inclusion cohort
-# - 1002 = Exclusion cohort
+# Preferred: entries from manifest query results
+inclusionEntry <- cohortManifest$queryCohortsByLabel("Inclusion cohort")
+exclusionEntry <- cohortManifest$queryCohortsByLabel("Exclusion cohort")
 
 cohortManifest$addDependentCustomCohort(
   filePath = here::here("inputs/cohorts/sql/my_custom_dependent.sql"),
   label = "Eligible_With_Exclusions",
   category = "Derived Cohorts",
   dependentCohortIdList = list(
-    inc_cohort_id = 1001L,
-    exc_cohort_id = 1002L
+    inc_cohort_id = inclusionEntry,
+    exc_cohort_id = exclusionEntry
+  ),
+  # Optional: any other values (not cohort IDs) to render into the SQL too
+  sqlParameters = list(
+    min_days = 30L
   ),
   tags = list(owner = "epi_team", source = "custom_sql")
 )
@@ -579,10 +590,26 @@ cohortManifest$addDependentCustomCohort(
 How it works:
 
 - `dependentCohortIdList` is a **named mapping** of SqlRender parameter name to
-  cohort ID.
-- Parameter names are flexible (for example `inc_cohort_id`, `exc_cohort_id`,
-  `baseline_cohort_id`) and are injected at runtime.
-- All mapped cohort IDs must already exist in the manifest.
+  a dependent cohort. Parameter names are flexible (for example `inc_cohort_id`,
+  `exc_cohort_id`, `baseline_cohort_id`).
+  - Preferred: a manifest entry (a data.frame/tibble with an `id` column, as
+    returned by `queryCohortsByLabel()` and similar query methods) — a single
+    row bakes in one ID, a multi-row table bakes in a comma-separated vector
+    of IDs, for `IN (@param)` clauses. Same pattern as `baseCohortEntry`/
+    `cohortEntries` on the built-in derived builders.
+  - Backward compatible: a raw integer cohort ID (or integer vector).
+  - All referenced cohort IDs must already exist in the manifest, and they
+    become this cohort's `depends_on` parents for staleness tracking.
+- `sqlParameters` is an optional **named mapping** of SqlRender parameter name
+  to any other value (thresholds, dates, strings, etc.) you want baked into the
+  SQL. These are not treated as cohort dependencies.
+- Both are rendered into the SQL at registration time — not at runtime.
+- When `dependentCohortIdList` entries are manifest entries with a `label`
+  column, those labels (purely for QC) are written into a generated comment
+  header at the top of the derived SQL file — e.g.
+  `inc_cohort_id: id 1001, label Inclusion cohort` — so anyone reading the
+  generated file can see at a glance which cohorts were baked in, without
+  cross-referencing the manifest.
 
 Your SQL file should reference the mapped placeholders:
 
@@ -697,57 +724,58 @@ SELECT
 FROM T1;
 
 ```
-Notice that in this template I am using cohort I have already created but building a custom derivation to analyze. I want to do this for several cohorts in my manifest. 
-I apply this sql template in an R function to create each custom derived cohort and add it to the manifest. 
+Notice that in this template I am using cohorts I have already created but building a custom derivation to analyze. I want to do this for several inclusion/exclusion pairs in my manifest.
+
+Because `addDependentCustomCohort()` renders `dependentCohortIdList`/`sqlParameters`
+into the SQL and writes the result to `inputs/cohorts/derived/<label>.sql` itself,
+the template file in `inputs/cohorts/R/src/sql` can be reused as-is, unmodified,
+for every pair — there's no need to hand-copy or pre-render it first. I apply this
+sql template in an R function to build each custom derived cohort from the manifest:
 
 ```{r}
 
 buildCensoredComplement <- function(
   cohortManifest,
-  inclusionCohortId,
-  inclusionCohortLabel,
-  exclusionCohortId,
-  exclusionCohortLabel,
-  inputsDir = here::here("inputs/cohorts/R"),
-  outputPath = here::here("inputs/cohorts/sql")
+  inclusionEntry,
+  exclusionEntry,
+  inputsDir = here::here("inputs/cohorts/R")
 ) {
 
   sqlTemplatePath <- fs::path(inputsDir, "src/sql/censored_complement.sql")
-  sqlTemplate <- SqlRender::readSql(sqlTemplatePath)
 
-  # make the save label
-  cohortLabel <- glue::glue("{inclusionCohortLabel} - {exclusionCohortLabel} exclusion")
-  outputLabel <- snakecase::to_snake_case(cohortLabel)
-
-  sqlOutputPath <- fs::path(outputPath, outputLabel, ext = "sql")
-  SqlRender::writeSql(sqlTemplate, sqlOutputPath)
+  cohortLabel <- glue::glue("{inclusionEntry$label[1]} - {exclusionEntry$label[1]} exclusion")
 
   check_if_there <- is.null(cohortManifest$queryCohortsByLabel(cohortLabel))
   if (!check_if_there) {
     cli::cli_alert_warning("Censored Complement {.val {cohortLabel}} already exists. Skipped!")
   } else {
     cli::cli_alert_info("Create Censored Complement for {.val {cohortLabel}}")
-    cli::cli_alert_success("Save Censored Complement to {.file {sqlOutputPath}}")
     cohortManifest$addDependentCustomCohort(
-      filePath = sqlOutputPath,
+      filePath = sqlTemplatePath,
       label = cohortLabel,
       category = "Target Sub Pop",
       dependentCohortIdList = list(
-        inc_cohort_id = inclusionCohortId,
-        exc_cohort_id = exclusionCohortId
+        inc_cohort_id = inclusionEntry,
+        exc_cohort_id = exclusionEntry
       )
     )
   }
 
-  invisible(sqlOutputPath)
+  invisible(cohortLabel)
 }
 ```
 
-In the derived cohort template, I do not replace the `@inc_cohort_id`
-or `@exc_cohort_id`. The `$addDependentCustomCohort` keeps track of these labels and renders them at execution time. 
+`addDependentCustomCohort()` reads `sqlTemplatePath`, renders `@inc_cohort_id`/
+`@exc_cohort_id` with the literal cohort IDs, and writes the result to its own
+generated file under `inputs/cohorts/derived/` — so the same template is safely
+reused across calls, since each call produces its own uniquely named output
+(named after `label`), never overwriting the template or another cohort's file.
 
-These same templating strategies can be applied to `$addSqlCohort`. Ensure that the template is in the `inputs/cohorts/R/src/sql` folder
-and the R script to render the template is in `inputs/cohorts/R/src`.
+This templating strategy can also be applied to `$addSqlCohort`, which does *not*
+render or bake parameters into the file — keep the template in
+`inputs/cohorts/R/src/sql` and pre-render it yourself (for example with
+`SqlRender::render()`) before registering, since `addSqlCohort()` registers
+whatever file it's given as-is.
 
 ---
 

--- a/inst/templates/loadScript_cohorts_buildDependentCohorts.R
+++ b/inst/templates/loadScript_cohorts_buildDependentCohorts.R
@@ -181,26 +181,45 @@ cohortManifest$tabulateManifest()
 # Register a dependency-aware custom SQL cohort that references existing cohorts
 # via SqlRender parameters in the SQL file.
 
+# incEntry <- cohortManifest$queryCohortsByLabel("Inclusion cohort")
+# excEntry <- cohortManifest$queryCohortsByLabel("Exclusion cohort")
+#
 # cohortManifest$addDependentCustomCohort(
 #   filePath = here::here("inputs/cohorts/sql/my_custom_dependent.sql"),
 #   label = "Eligible_With_Exclusions",
 #   category = "Derived Cohorts",
 #   dependentCohortIdList = list(
-#     inc_cohort_id = 1001L,
-#     exc_cohort_id = 1002L
+#     # Preferred: manifest entries (data.frame/tibble with an id column) -
+#     # same pattern as baseCohortEntry/cohortEntries on the builders above.
+#     # Backward compatible: raw integer IDs also still work.
+#     inc_cohort_id = incEntry,
+#     exc_cohort_id = excEntry
+#   ),
+#   # sqlParameters: optional extra values (not cohort IDs) to render into the SQL
+#   sqlParameters = list(
+#     min_days = 30L
 #   ),
 #   tags = list(owner = "epi_team", source = "custom_sql")
 # )
 
 # SQL contract reminder for my_custom_dependent.sql:
-#   - Use @inc_cohort_id and @exc_cohort_id placeholders (or your own named keys)
+#   - Use @inc_cohort_id, @exc_cohort_id, @min_days, etc. placeholders (or your own named keys)
 #   - DELETE from @target_database_schema.@target_cohort_table by @target_cohort_id
 #   - INSERT into @target_database_schema.@target_cohort_table
 #       (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
+#
+# dependentCohortIdList/sqlParameters values are rendered into the SQL immediately,
+# and the rendered file is written to inputs/cohorts/derived/<label>.sql (the file
+# actually registered in the manifest) - just like the built-in derived cohort
+# builders above. Only @target_cohort_id and the other connection/schema
+# placeholders are left for generateCohorts() to fill in at execution time.
+# When dependentCohortIdList entries carry a label (i.e. manifest entries, not
+# raw IDs), that label is written into a "Dependent cohorts" comment header at
+# the top of the generated file, for QC.
 
 # Note that users can build dependent sql cohorts with templates via R functions. Any
 # code should be saved in inputs/cohorts/R/src. add another folder called /sql in here
-# for the templates! 
+# for the templates!
 
 
 # ================================================================================

--- a/man/CohortManifest.Rd
+++ b/man/CohortManifest.Rd
@@ -410,13 +410,19 @@ Batch-import cohorts from ATLAS via a cohortsLoad dataframe
 Either create a dataframe or read in a csv file with columns \code{atlasId}, \code{label}, \code{category} (required) plus any
 additional columns treated as tag key-value pairs for tags. Calls \code{addAtlasCohort()} for each row.
 
-The load file is a transient, one-time import mechanism: rows whose
-atlasId or label are already registered in the manifest are an error, not
-an update. To sync registered cohorts with ATLAS, run
-\code{updateAtlasCohorts()}; to update a single cohort, use
-\code{addAtlasCohort(stopIfExists = FALSE)}.
+By default, the load file is treated as a transient, one-time import
+mechanism: rows whose atlasId is already registered in the manifest are
+an error, not an update. Set \code{stopIfExists = FALSE} to instead update
+those rows in place (delegates to \code{addAtlasCohort(stopIfExists = FALSE)}
+for each), which supports iterating on the load file across repeated
+runs. To sync registered cohorts with ATLAS without a load file, use
+\code{updateAtlasCohorts()}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{CohortManifest$importAtlasCohorts(cohortsLoad, atlasConnection = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{CohortManifest$importAtlasCohorts(
+  cohortsLoad,
+  atlasConnection = NULL,
+  stopIfExists = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -426,6 +432,12 @@ an update. To sync registered cohorts with ATLAS, run
 
 \item{\code{atlasConnection}}{An ATLAS connection object with a \code{getCohortDefinition(cohortId)} method.
 If \code{NULL}, falls back to the connection stored via \verb{$setAtlasConnection()}.}
+
+\item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when any
+load row's atlasId is already registered in the manifest. If FALSE,
+those rows are updated in place instead (same ID/file path, hash
+refreshed, category/tags replaced) via \code{addAtlasCohort(stopIfExists = FALSE)}.
+Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/CohortManifest.Rd
+++ b/man/CohortManifest.Rd
@@ -565,16 +565,24 @@ Invisible integer. The assigned cohort ID.
 \subsection{Method \code{addDependentCustomCohort()}}{
 Add a dependent custom SQL cohort
 
-Registers an existing SQL file in the manifest as a dependency-aware derived cohort.
-The SQL file must already exist on disk and must preserve the standard Picard
-cohort write contract using \.code{@target_database_schema.@target_cohort_table}
-and \.code{@target_cohort_id}.
+Registers a SQL file in the manifest as a dependency-aware derived cohort.
+The source SQL file must preserve the standard Picard cohort write contract
+using \.code{@target_database_schema.@target_cohort_table} and
+\.code{@target_cohort_id}.
+
+\code{dependentCohortIdList} and \code{sqlParameters} values are rendered into the
+source SQL immediately (via \.code{SqlRender::render()}) and the result is
+written to \.code{inputs/cohorts/derived/\if{html}{\out{<label>}}.sql} — the file registered
+in the manifest — exactly like the built-in derived cohort types (subset,
+union, etc.). Only the connection/schema placeholders (\.code{@target_cohort_id}
+and friends) are left for \.code{generateCohorts()} to fill in at execution time.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{CohortManifest$addDependentCustomCohort(
   filePath,
   label,
   category,
   dependentCohortIdList,
+  sqlParameters = list(),
   tags = list(),
   stopIfExists = TRUE
 )}\if{html}{\out{</div>}}
@@ -583,26 +591,36 @@ and \.code{@target_cohort_id}.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{filePath}}{Character. Path to the SQL file.}
+\item{\code{filePath}}{Character. Path to the source SQL file/template.}
 
 \item{\code{label}}{Character. Display name for the cohort.}
 
 \item{\code{category}}{Character. Required classification.}
 
-\item{\code{dependentCohortIdList}}{Named list. Each name is a SqlRender parameter to expose
-in the SQL file and each value is the cohort ID — or an integer vector of
-cohort IDs — to inject at runtime. Vectors render comma-separated, for use
-in \.code{IN (@param)} clauses.
-Example: \.code{list(inc_cohort_id = 10L, exc_cohort_ids = c(12L, 14L))}.}
+\item{\code{dependentCohortIdList}}{Named list. Each name is a SqlRender parameter to
+render into the SQL file. Each value is, preferably, a manifest entry —
+a data.frame/tibble with an \.code{id} column, as returned by query methods
+like \.code{queryCohortsByLabel()} (a single row bakes in one ID; a multi-row
+table bakes in a comma-separated vector, for \.code{IN (@param)} clauses) —
+or, for backward compatibility, a raw integer cohort ID (or integer vector).
+These IDs also become this cohort's \.code{depends_on} parents for staleness
+tracking. When entries carry a \.code{label} column, it's included (purely
+for QC) in a generated comment header at the top of the derived SQL file.
+Example: \.code{list(inc_cohort_id = ckdEntry, exc_cohort_id = t2dEntry)}.}
+
+\item{\code{sqlParameters}}{Named list. Optional additional SqlRender parameters to
+render into the SQL file (any type — thresholds, dates, strings, etc.),
+not treated as cohort dependencies.
+Example: \.code{list(min_days = 30L, index_year = 2020L)}.}
 
 \item{\code{tags}}{Named list. Optional metadata tags.}
 
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered cohort in place (same ID): the dependent cohort
-IDs and the SQL file registration (path and content hash) are replaced,
-the cohort is marked 'stale' for regeneration, and its own dependents
-are marked stale too. Default: TRUE (fail-safe).}
+IDs/sqlParameters are re-rendered into the generated file, the cohort is
+marked 'stale' for regeneration, and its own dependents are marked stale
+too. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ConceptSetManifest.Rd
+++ b/man/ConceptSetManifest.Rd
@@ -16,11 +16,12 @@ The ConceptSetManifest class manages multiple concept set definitions and stores
 metadata in a SQLite database located at inputs/conceptSets/conceptSetManifest.sqlite.
 Each ConceptSetDef is assigned a sequential ID based on its position in the manifest.
 
-The load file is a transient, one-time import mechanism: rows whose
-atlasId or label are already registered in the manifest are an error, not
-an update. To sync registered concept sets with ATLAS, run
-\code{updateAtlasConceptSets()}; to update a single concept set, use
-\code{addAtlasConceptSet(stopIfExists = FALSE)}.
+By default, the load file is treated as a transient, one-time import
+mechanism: rows whose atlasId is already registered in the manifest are
+an error, not an update. Set \code{stopIfExists = FALSE} to instead update
+those rows in place, which supports iterating on the load file across
+repeated runs. To sync registered concept sets with ATLAS without a
+load file, use \code{updateAtlasConceptSets()}.
 
 \strong{Processing Steps:}
 \enumerate{
@@ -503,7 +504,8 @@ a \code{tryCatch} so a single failure does not abort the entire batch.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{ConceptSetManifest$importAtlasConceptSets(
   conceptSetsLoad,
-  atlasConnection = NULL
+  atlasConnection = NULL,
+  stopIfExists = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -515,6 +517,12 @@ a \code{tryCatch} so a single failure does not abort the entire batch.
 \item{\code{atlasConnection}}{An ATLAS connection object with a
 \code{getConceptSetDefinition(conceptSetId)} method.
 If \code{NULL}, falls back to the connection stored via \verb{$setAtlasConnection()}.}
+
+\item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when any
+load row's atlasId is already registered in the manifest. If FALSE,
+those rows are updated in place instead (same ID/file path, hash
+refreshed, category/tags replaced) via \code{addAtlasConceptSet(stopIfExists = FALSE)}.
+Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-CohortManifest-management.R
+++ b/tests/testthat/test-CohortManifest-management.R
@@ -679,6 +679,37 @@ testthat::test_that("importAtlasCohorts errors on already-registered rows", {
   )
 })
 
+# Testing: importAtlasCohorts stopIfExists = FALSE updates already-registered rows in place
+# instead of erroring, supporting re-running the same load file while iterating.
+testthat::test_that("importAtlasCohorts stopIfExists FALSE updates existing rows in place", {
+  setup <- cm_test_new_manifest("mgmt-atlas-import-upsert")
+  manifest <- setup$manifest
+  jsons <- cm_test_atlas_fixture_jsons()
+
+  load_df <- data.frame(atlasId = 100L, label = "Atlas Cohort", category = "Target")
+  conn_v1 <- cm_test_fake_atlas_connection(list("100" = jsons$v1))
+  manifest$importAtlasCohorts(cohortsLoad = load_df, atlasConnection = conn_v1)
+  before <- cm_test_get_manifest_row(manifest, "Atlas Cohort")
+
+  # Re-running with stopIfExists = FALSE and a changed definition updates in place
+  conn_v2 <- cm_test_fake_atlas_connection(list("100" = jsons$v2))
+  manifest$importAtlasCohorts(cohortsLoad = load_df, atlasConnection = conn_v2, stopIfExists = FALSE)
+  after <- cm_test_get_manifest_row(manifest, "Atlas Cohort")
+  testthat::expect_equal(nrow(after), 1)
+  testthat::expect_equal(after$id[[1]], before$id[[1]])
+  testthat::expect_false(identical(after$hash[[1]], before$hash[[1]]))
+
+  # A mix of a new row and an already-registered row processes both
+  mixed_df <- data.frame(
+    atlasId = c(100L, 200L),
+    label = c("Atlas Cohort", "Second Atlas Cohort"),
+    category = c("Target", "Target")
+  )
+  conn_both <- cm_test_fake_atlas_connection(list("100" = jsons$v2, "200" = jsons$v2))
+  manifest$importAtlasCohorts(cohortsLoad = mixed_df, atlasConnection = conn_both, stopIfExists = FALSE)
+  testthat::expect_equal(nrow(cm_test_get_manifest_row(manifest, "Second Atlas Cohort")), 1)
+})
+
 # Testing: addAtlasCohort stopIfExists = FALSE refreshes a single cohort from ATLAS in place.
 testthat::test_that("addAtlasCohort stopIfExists FALSE updates from ATLAS in place", {
   setup <- cm_test_new_manifest("mgmt-atlas-add-upsert")

--- a/tests/testthat/test-CohortManifest-management.R
+++ b/tests/testthat/test-CohortManifest-management.R
@@ -437,7 +437,7 @@ testthat::test_that("addDependentCustomCohort stopIfExists FALSE updates deps an
 })
 
 # Testing: dependentCohortIdList entries accept vectors of IDs, stored in depends_on
-# and rendered comma-separated at generation time.
+# and baked comma-separated into the generated derived SQL file.
 testthat::test_that("addDependentCustomCohort accepts vectors of dependent IDs", {
   setup <- cm_test_new_manifest("mgmt-depcustom-vector")
   manifest <- setup$manifest
@@ -470,20 +470,64 @@ testthat::test_that("addDependentCustomCohort accepts vectors of dependent IDs",
     c(ckd_id, t2d_id, death_id)
   )
 
-  # Generation-side round trip: params come back atomic and render for IN clauses
-  conn <- DBI::dbConnect(RSQLite::SQLite(), manifest$getDbPath())
-  on.exit(DBI::dbDisconnect(conn), add = TRUE)
-  params <- get_custom_derived_sql_params(conn, as.integer(dep_id))
-  testthat::expect_false(is.list(params$exc_cohort_id))
-  testthat::expect_equal(as.integer(params$exc_cohort_id), c(t2d_id, death_id))
+  # The dependent IDs are baked directly into the generated derived SQL file
+  # (like the other derived cohort types) - the vector renders comma-separated
+  # and the original @inc_cohort_id/@exc_cohort_id placeholders are gone.
+  testthat::expect_true(grepl("inputs/cohorts/derived", row$file_path[[1]], fixed = TRUE))
+  rendered_sql <- readr::read_file(row$file_path[[1]])
+  testthat::expect_false(grepl("@inc_cohort_id", rendered_sql, fixed = TRUE))
+  testthat::expect_false(grepl("@exc_cohort_id", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl(as.character(t2d_id), rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl(as.character(death_id), rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl(paste0(t2d_id, ",", death_id), rendered_sql, fixed = TRUE))
 
-  rendered <- SqlRender::render(
-    "cohort_definition_id IN (@exc_cohort_id)",
-    exc_cohort_id = params$exc_cohort_id
+  # Connection/schema placeholders are left for generateCohorts() to fill in
+  testthat::expect_true(grepl("@target_cohort_id", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl("@target_database_schema", rendered_sql, fixed = TRUE))
+})
+
+# Testing: dependentCohortIdList accepts manifest entries (data.frame/tibble
+# with an id column), like the other dependent cohort builders, and renders
+# their labels into a QC header comment on the generated derived SQL file.
+testthat::test_that("addDependentCustomCohort accepts manifest entries and renders a QC header", {
+  setup <- cm_test_new_manifest("mgmt-depcustom-entries")
+  manifest <- setup$manifest
+
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Chronic Kidney Disease", fixture_name = "ckd.json")
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Type 2 Diabetes", fixture_name = "t2d.json")
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "All-Cause Death", fixture_name = "death.json")
+
+  ckd_entry <- manifest$queryCohortsByLabel("Chronic Kidney Disease")
+  exclusion_entries <- manifest$queryCohortsByLabel(c("Type 2 Diabetes", "All-Cause Death"))
+  t2d_id <- as.integer(exclusion_entries$id[exclusion_entries$label == "Type 2 Diabetes"][1])
+  death_id <- as.integer(exclusion_entries$id[exclusion_entries$label == "All-Cause Death"][1])
+
+  fixture <- cm_test_sql_fixture_path("my_custom_dependent.sql")
+  local_sql <- fs::path(setup$paths$sql_dir, "my_custom_dependent.sql")
+  fs::file_copy(fixture, local_sql)
+
+  manifest$addDependentCustomCohort(
+    filePath = local_sql,
+    label = "Dep Entries",
+    category = "Derived Cohorts",
+    dependentCohortIdList = list(
+      inc_cohort_id = ckd_entry,
+      exc_cohort_id = exclusion_entries
+    )
   )
-  testthat::expect_true(grepl(as.character(t2d_id), rendered, fixed = TRUE))
-  testthat::expect_true(grepl(as.character(death_id), rendered, fixed = TRUE))
-  testthat::expect_true(grepl(",", rendered, fixed = TRUE))
+
+  row <- cm_test_get_manifest_row(manifest, "Dep Entries")
+  testthat::expect_equal(
+    sort(jsonlite::fromJSON(row$depends_on[[1]])),
+    sort(c(as.integer(ckd_entry$id[1]), t2d_id, death_id))
+  )
+
+  rendered_sql <- readr::read_file(row$file_path[[1]])
+  testthat::expect_true(grepl("Dependent cohorts", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl("Chronic Kidney Disease", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl("Type 2 Diabetes", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl("All-Cause Death", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl(as.character(ckd_entry$id[1]), rendered_sql, fixed = TRUE))
 })
 
 # Testing: addDependentCustomCohort default stopIfExists = TRUE errors on duplicate labels.
@@ -516,6 +560,93 @@ testthat::test_that("addDependentCustomCohort errors on duplicate label by defau
       dependentCohortIdList = list(inc_cohort_id = ckd_id, exc_cohort_id = t2d_id)
     ),
     regexp = "already in use"
+  )
+})
+
+# Testing: sqlParameters render arbitrary (non cohort-ID) values into the
+# generated derived SQL file alongside dependentCohortIdList.
+testthat::test_that("addDependentCustomCohort renders sqlParameters into the generated file", {
+  setup <- cm_test_new_manifest("mgmt-depcustom-sqlparams")
+  manifest <- setup$manifest
+
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Chronic Kidney Disease", fixture_name = "ckd.json")
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Type 2 Diabetes", fixture_name = "t2d.json")
+  rows <- manifest$tabulateManifest(filter = "active")
+  ckd_id <- as.integer(rows$id[rows$label == "Chronic Kidney Disease"][1])
+  t2d_id <- as.integer(rows$id[rows$label == "Type 2 Diabetes"][1])
+
+  local_sql <- fs::path(setup$paths$sql_dir, "my_custom_dependent_params.sql")
+  writeLines(c(
+    "DELETE FROM @target_database_schema.@target_cohort_table",
+    "WHERE cohort_definition_id = @target_cohort_id;",
+    "",
+    "INSERT INTO @target_database_schema.@target_cohort_table",
+    "  (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)",
+    "SELECT",
+    "  @target_cohort_id,",
+    "  i.subject_id,",
+    "  i.cohort_start_date,",
+    "  DATEADD(day, @min_days, i.cohort_start_date)",
+    "FROM @target_database_schema.@target_cohort_table i",
+    "WHERE i.cohort_definition_id = @inc_cohort_id",
+    "  AND i.cohort_definition_id != @exc_cohort_id;"
+  ), local_sql)
+
+  manifest$addDependentCustomCohort(
+    filePath = local_sql,
+    label = "Dep Params",
+    category = "Derived Cohorts",
+    dependentCohortIdList = list(inc_cohort_id = ckd_id, exc_cohort_id = t2d_id),
+    sqlParameters = list(min_days = 30L)
+  )
+
+  row <- cm_test_get_manifest_row(manifest, "Dep Params")
+  rendered_sql <- readr::read_file(row$file_path[[1]])
+  testthat::expect_true(grepl("DATEADD(day, 30,", rendered_sql, fixed = TRUE))
+  testthat::expect_false(grepl("@min_days", rendered_sql, fixed = TRUE))
+  testthat::expect_false(grepl("@inc_cohort_id", rendered_sql, fixed = TRUE))
+  testthat::expect_true(grepl(as.character(ckd_id), rendered_sql, fixed = TRUE))
+
+  rule <- jsonlite::fromJSON(row$dependency_rule[[1]])
+  testthat::expect_equal(as.integer(rule$sqlParameters$min_days), 30L)
+})
+
+# Testing: sqlParameters cannot collide with dependentCohortIdList names or
+# reserved (connection/schema) SqlRender parameter names.
+testthat::test_that("addDependentCustomCohort errors on sqlParameters name collisions", {
+  setup <- cm_test_new_manifest("mgmt-depcustom-sqlparams-collision")
+  manifest <- setup$manifest
+
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Chronic Kidney Disease", fixture_name = "ckd.json")
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Type 2 Diabetes", fixture_name = "t2d.json")
+  rows <- manifest$tabulateManifest(filter = "active")
+  ckd_id <- as.integer(rows$id[rows$label == "Chronic Kidney Disease"][1])
+  t2d_id <- as.integer(rows$id[rows$label == "Type 2 Diabetes"][1])
+
+  fixture <- cm_test_sql_fixture_path("my_custom_dependent.sql")
+  local_sql <- fs::path(setup$paths$sql_dir, "my_custom_dependent.sql")
+  fs::file_copy(fixture, local_sql)
+
+  testthat::expect_error(
+    manifest$addDependentCustomCohort(
+      filePath = local_sql,
+      label = "Dep Collide",
+      category = "Derived Cohorts",
+      dependentCohortIdList = list(inc_cohort_id = ckd_id, exc_cohort_id = t2d_id),
+      sqlParameters = list(inc_cohort_id = 5L)
+    ),
+    regexp = "cannot share parameter name"
+  )
+
+  testthat::expect_error(
+    manifest$addDependentCustomCohort(
+      filePath = local_sql,
+      label = "Dep Reserved",
+      category = "Derived Cohorts",
+      dependentCohortIdList = list(inc_cohort_id = ckd_id, exc_cohort_id = t2d_id),
+      sqlParameters = list(target_cohort_id = 5L)
+    ),
+    regexp = "reserved SqlRender parameter"
   )
 })
 

--- a/tests/testthat/test-ConceptSetManifest-management.R
+++ b/tests/testthat/test-ConceptSetManifest-management.R
@@ -203,6 +203,37 @@ testthat::test_that("importAtlasConceptSets errors on already-registered rows", 
   )
 })
 
+# Testing: importAtlasConceptSets stopIfExists = FALSE updates already-registered rows in place
+# instead of erroring, supporting re-running the same load file while iterating.
+testthat::test_that("importAtlasConceptSets stopIfExists FALSE updates existing rows in place", {
+  setup <- csm_test_new_manifest("csm-atlas-import-upsert")
+  manifest <- setup$manifest
+  jsons <- csm_test_atlas_fixture_jsons()
+
+  load_df <- data.frame(atlasId = 200L, label = "Atlas Concepts", category = "condition_occurrence")
+  conn_v1 <- csm_test_fake_atlas_connection(list("200" = jsons$v1))
+  manifest$importAtlasConceptSets(conceptSetsLoad = load_df, atlasConnection = conn_v1)
+  before <- csm_test_get_manifest_row(manifest, "Atlas Concepts")
+
+  # Re-running with stopIfExists = FALSE and a changed definition updates in place
+  conn_v2 <- csm_test_fake_atlas_connection(list("200" = jsons$v2))
+  manifest$importAtlasConceptSets(conceptSetsLoad = load_df, atlasConnection = conn_v2, stopIfExists = FALSE)
+  after <- csm_test_get_manifest_row(manifest, "Atlas Concepts")
+  testthat::expect_equal(nrow(after), 1)
+  testthat::expect_equal(after$id[[1]], before$id[[1]])
+  testthat::expect_false(identical(after$hash[[1]], before$hash[[1]]))
+
+  # A mix of a new row and an already-registered row processes both
+  mixed_df <- data.frame(
+    atlasId = c(200L, 300L),
+    label = c("Atlas Concepts", "Second Atlas Concepts"),
+    category = c("condition_occurrence", "condition_occurrence")
+  )
+  conn_both <- csm_test_fake_atlas_connection(list("200" = jsons$v2, "300" = jsons$v2))
+  manifest$importAtlasConceptSets(conceptSetsLoad = mixed_df, atlasConnection = conn_both, stopIfExists = FALSE)
+  testthat::expect_equal(nrow(csm_test_get_manifest_row(manifest, "Second Atlas Concepts")), 1)
+})
+
 # Testing: addAtlasConceptSet stopIfExists = FALSE refreshes a single concept set from ATLAS in place.
 testthat::test_that("addAtlasConceptSet stopIfExists FALSE updates from ATLAS in place", {
   setup <- csm_test_new_manifest("csm-atlas-add-upsert")

--- a/vignettes/loading_inputs.Rmd
+++ b/vignettes/loading_inputs.Rmd
@@ -560,22 +560,33 @@ for comprehensive examples of all derived cohort types.
 Use this pattern when a custom SQL cohort depends on one or more previously
 defined cohorts (for example inclusion/exclusion cohorts). This registers the
 cohort as a dependency-aware derived type (`custom_derived`) so execution order,
-stale detection, and dependency hashing are handled automatically. 
+stale detection, and dependency hashing are handled automatically.
+
+Like the built-in derived cohort builders (subset, union, etc.), the values you
+supply are rendered into the SQL immediately and the rendered file is written to
+`inputs/cohorts/derived/<label>.sql` — that generated file, not your source file,
+is what's registered in the manifest. Only the connection/schema placeholders
+(`@target_cohort_id` and friends) are left unrendered, for `generateCohorts()`
+to fill in at execution time.
 
 ```{r}
 cohortManifest <- loadCohortManifest()
 
-# Example dependencies already in the manifest:
-# - 1001 = Inclusion cohort
-# - 1002 = Exclusion cohort
+# Preferred: entries from manifest query results
+inclusionEntry <- cohortManifest$queryCohortsByLabel("Inclusion cohort")
+exclusionEntry <- cohortManifest$queryCohortsByLabel("Exclusion cohort")
 
 cohortManifest$addDependentCustomCohort(
   filePath = here::here("inputs/cohorts/sql/my_custom_dependent.sql"),
   label = "Eligible_With_Exclusions",
   category = "Derived Cohorts",
   dependentCohortIdList = list(
-    inc_cohort_id = 1001L,
-    exc_cohort_id = 1002L
+    inc_cohort_id = inclusionEntry,
+    exc_cohort_id = exclusionEntry
+  ),
+  # Optional: any other values (not cohort IDs) to render into the SQL too
+  sqlParameters = list(
+    min_days = 30L
   ),
   tags = list(owner = "epi_team", source = "custom_sql")
 )
@@ -584,10 +595,26 @@ cohortManifest$addDependentCustomCohort(
 How it works:
 
 - `dependentCohortIdList` is a **named mapping** of SqlRender parameter name to
-  cohort ID.
-- Parameter names are flexible (for example `inc_cohort_id`, `exc_cohort_id`,
-  `baseline_cohort_id`) and are injected at runtime.
-- All mapped cohort IDs must already exist in the manifest.
+  a dependent cohort. Parameter names are flexible (for example `inc_cohort_id`,
+  `exc_cohort_id`, `baseline_cohort_id`).
+  - Preferred: a manifest entry (a data.frame/tibble with an `id` column, as
+    returned by `queryCohortsByLabel()` and similar query methods) — a single
+    row bakes in one ID, a multi-row table bakes in a comma-separated vector
+    of IDs, for `IN (@param)` clauses. Same pattern as `baseCohortEntry`/
+    `cohortEntries` on the built-in derived builders.
+  - Backward compatible: a raw integer cohort ID (or integer vector).
+  - All referenced cohort IDs must already exist in the manifest, and they
+    become this cohort's `depends_on` parents for staleness tracking.
+- `sqlParameters` is an optional **named mapping** of SqlRender parameter name
+  to any other value (thresholds, dates, strings, etc.) you want baked into the
+  SQL. These are not treated as cohort dependencies.
+- Both are rendered into the SQL at registration time — not at runtime.
+- When `dependentCohortIdList` entries are manifest entries with a `label`
+  column, those labels (purely for QC) are written into a generated comment
+  header at the top of the derived SQL file — e.g.
+  `inc_cohort_id: id 1001, label Inclusion cohort` — so anyone reading the
+  generated file can see at a glance which cohorts were baked in, without
+  cross-referencing the manifest.
 
 Your SQL file should reference the mapped placeholders:
 
@@ -702,57 +729,58 @@ SELECT
 FROM T1;
 
 ```
-Notice that in this template I am using cohort I have already created but building a custom derivation to analyze. I want to do this for several cohorts in my manifest. 
-I apply this sql template in an R function to create each custom derived cohort and add it to the manifest. 
+Notice that in this template I am using cohorts I have already created but building a custom derivation to analyze. I want to do this for several inclusion/exclusion pairs in my manifest.
+
+Because `addDependentCustomCohort()` renders `dependentCohortIdList`/`sqlParameters`
+into the SQL and writes the result to `inputs/cohorts/derived/<label>.sql` itself,
+the template file in `inputs/cohorts/R/src/sql` can be reused as-is, unmodified,
+for every pair — there's no need to hand-copy or pre-render it first. I apply this
+sql template in an R function to build each custom derived cohort from the manifest:
 
 ```{r}
 
 buildCensoredComplement <- function(
   cohortManifest,
-  inclusionCohortId,
-  inclusionCohortLabel,
-  exclusionCohortId,
-  exclusionCohortLabel,
-  inputsDir = here::here("inputs/cohorts/R"),
-  outputPath = here::here("inputs/cohorts/sql")
+  inclusionEntry,
+  exclusionEntry,
+  inputsDir = here::here("inputs/cohorts/R")
 ) {
 
   sqlTemplatePath <- fs::path(inputsDir, "src/sql/censored_complement.sql")
-  sqlTemplate <- SqlRender::readSql(sqlTemplatePath)
 
-  # make the save label
-  cohortLabel <- glue::glue("{inclusionCohortLabel} - {exclusionCohortLabel} exclusion")
-  outputLabel <- snakecase::to_snake_case(cohortLabel)
-
-  sqlOutputPath <- fs::path(outputPath, outputLabel, ext = "sql")
-  SqlRender::writeSql(sqlTemplate, sqlOutputPath)
+  cohortLabel <- glue::glue("{inclusionEntry$label[1]} - {exclusionEntry$label[1]} exclusion")
 
   check_if_there <- is.null(cohortManifest$queryCohortsByLabel(cohortLabel))
   if (!check_if_there) {
     cli::cli_alert_warning("Censored Complement {.val {cohortLabel}} already exists. Skipped!")
   } else {
     cli::cli_alert_info("Create Censored Complement for {.val {cohortLabel}}")
-    cli::cli_alert_success("Save Censored Complement to {.file {sqlOutputPath}}")
     cohortManifest$addDependentCustomCohort(
-      filePath = sqlOutputPath,
+      filePath = sqlTemplatePath,
       label = cohortLabel,
       category = "Target Sub Pop",
       dependentCohortIdList = list(
-        inc_cohort_id = inclusionCohortId,
-        exc_cohort_id = exclusionCohortId
+        inc_cohort_id = inclusionEntry,
+        exc_cohort_id = exclusionEntry
       )
     )
   }
 
-  invisible(sqlOutputPath)
+  invisible(cohortLabel)
 }
 ```
 
-In the derived cohort template, I do not replace the `@inc_cohort_id`
-or `@exc_cohort_id`. The `$addDependentCustomCohort` keeps track of these labels and renders them at execution time. 
+`addDependentCustomCohort()` reads `sqlTemplatePath`, renders `@inc_cohort_id`/
+`@exc_cohort_id` with the literal cohort IDs, and writes the result to its own
+generated file under `inputs/cohorts/derived/` — so the same template is safely
+reused across calls, since each call produces its own uniquely named output
+(named after `label`), never overwriting the template or another cohort's file.
 
-These same templating strategies can be applied to `$addSqlCohort`. Ensure that the template is in the `inputs/cohorts/R/src/sql` folder
-and the R script to render the template is in `inputs/cohorts/R/src`.
+This templating strategy can also be applied to `$addSqlCohort`, which does *not*
+render or bake parameters into the file — keep the template in
+`inputs/cohorts/R/src/sql` and pre-render it yourself (for example with
+`SqlRender::render()`) before registering, since `addSqlCohort()` registers
+whatever file it's given as-is.
 
 ---
 


### PR DESCRIPTION
Addresses #65 #66 #70 : 

- `stopIfExists` is now an option for the ATLAS csv load builders, making behavior consistent across all builders and enabling more reproducible input pipeline
- Custom dependent cohort builder is now consistent with the other dependent cohort builders - the rendered SQL query is written to the file system, and it accepts cohort objects as inputs instead of IDs. _**This is a breaking change but I think it's important to make the pipeline fully transparent.**_
  - IDs are actually still accepted for backward compatibility, but the fact that the file is written out is a breaking change. Users should be able to re-run the function to add their cohort as a file (but I didn't test this yet)
- Custom dependent cohort builder now also allows user to specify non-cohort-ID params, so the rendered SQL query can be generated in a single function call
- Builder console messages clarified