### PR TITLE
Fix stale status bugs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 - Add task prefix to the `importAndBind()` save to avoid similar output names between tasks.
 - Add method to ExecutionSettings to `reviewConnectionDetails()` pulls the connectionDetails used. 
 - Modify `getServerCredentials()` to not evaluate full yml file, only pull the specific block and evaluate (See issue #30, #33). 
+- Re-registering a derived cohort with `stopIfExists = FALSE` no longer marks it (and its dependents) `stale` when the definition is unchanged, so an accidental re-run of `$addDependentCustomCohort()` or a `build*Cohort()` method no longer drops the cohort out of the active manifest and out of query results. Staleness is now cascaded only on a real definition change; a metadata-only edit updates category/tags without forcing regeneration, and a cohort already marked `stale` stays stale.
+- Stale cohorts are no longer omitted from manifest summaries. Printing a `CohortManifest` counted only active + deleted cohorts, so "Total cohorts" appeared to shrink when cohorts were queued for regeneration; the total now includes stale cohorts, which are reported on their own `Stale:` line and listed separately. `$getManifestStatus()` gains a `stale_count` element, and its `missing_count` now also covers stale entries whose file is missing.
 
 # picard 0.0.6
 

--- a/R/CohortManifest.R
+++ b/R/CohortManifest.R
@@ -308,7 +308,8 @@ CohortManifest <- R6::R6Class(
 
       previous <- DBI::dbGetQuery(
         conn,
-        "SELECT hash, category, tags FROM cohort_manifest WHERE id = ?",
+        "SELECT hash, category, tags, file_path, depends_on, dependency_rule
+         FROM cohort_manifest WHERE id = ?",
         list(existingId)
       )
 
@@ -332,16 +333,25 @@ CohortManifest <- R6::R6Class(
       }
 
       # The rendered SQL captures depends_on/dependency_rule already (they're
-      # inlined into the template), so a hash diff is a proxy for any
-      # definition-affecting change
-      definition_changed <- !identical(hash, previous$hash[1])
+      # inlined into the template), so a hash diff is the main proxy for a
+      # definition-affecting change; the stored parents/rule and file path are
+      # compared too so nothing definition-level slips through unnoticed
+      definition_changed <- !identical(hash, previous$hash[1]) ||
+        !identical(as.character(file_path), as.character(previous$file_path[1])) ||
+        !identical(as.character(depends_on_json), as.character(previous$depends_on[1])) ||
+        !identical(as.character(dep_rule_json), as.character(previous$dependency_rule[1]))
       metadata_changed <- !identical(as.character(category), as.character(previous$category[1])) ||
         !identical(as.character(tags_json), as.character(previous$tags[1]))
 
-      set_clauses <- paste(
+      # Only a real definition change requires regeneration. Re-registering an
+      # identical definition (an accidental re-run) must leave status alone, or
+      # the cohort silently drops out of the active manifest; a metadata-only
+      # edit doesn't change what the cohort generates either.
+      status_clause <- if (definition_changed) " status = 'stale'," else ""
+      set_clauses <- paste0(
         "category = ?, file_path = ?, hash = ?, source_type = ?, cohort_type = ?,",
-        "depends_on = ?, dependency_rule = ?, tags = ?, status = 'stale',",
-        "updated_at = CURRENT_TIMESTAMP"
+        " depends_on = ?, dependency_rule = ?, tags = ?,", status_clause,
+        " updated_at = CURRENT_TIMESTAMP"
       )
       params <- list(category, file_path, hash, source_type, cohort_type, depends_on_json, dep_rule_json, tags_json)
 
@@ -352,7 +362,9 @@ CohortManifest <- R6::R6Class(
       )
 
       # This cohort's own dependents are now out of date too
-      cascadeStaleDownstream(private$.dbPath, existingId)
+      if (definition_changed) {
+        cascadeStaleDownstream(private$.dbPath, existingId)
+      }
 
       # Refresh in-memory manifest
       private$load_manifest_from_db()
@@ -366,7 +378,8 @@ CohortManifest <- R6::R6Class(
       } else {
         "no changes detected"
       }
-      cli::cli_alert_info("Updated derived cohort {existingId}: {label} — {change_desc} (marked stale for regeneration)")
+      stale_note <- if (definition_changed) " (marked stale for regeneration)" else ""
+      cli::cli_alert_info("Updated derived cohort {existingId}: {label} — {change_desc}{stale_note}")
       return(existingId)
     },
 
@@ -1886,9 +1899,11 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered cohort in place (same ID): the dependent cohort
-    #'   IDs/sqlParameters are re-rendered into the generated file, the cohort is
-    #'   marked 'stale' for regeneration, and its own dependents are marked stale
-    #'   too. Default: TRUE (fail-safe).
+    #'   IDs/sqlParameters are re-rendered into the generated file. When that
+    #'   changes the definition, the cohort is marked 'stale' for regeneration
+    #'   and its own dependents are marked stale too; re-registering an
+    #'   identical definition leaves the status untouched.
+    #'   Default: TRUE (fail-safe).
     #'
     #' @return Invisible integer. The assigned cohort ID.
     addDependentCustomCohort = function(filePath, label, category, dependentCohortIdList,
@@ -2003,9 +2018,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildUnionCohort = function(
       label, 
@@ -2146,9 +2162,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildSubsetCohortTemporal = function(
       label, 
@@ -2320,9 +2337,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildComplementCohort = function(
       label, 
@@ -2480,9 +2498,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildCompositeCohort = function(
         label, 
@@ -2598,9 +2617,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildDemographicCohort = function(label, baseCohortId = NULL, 
                                       baseCohortEntry = NULL, category,
@@ -3958,13 +3978,17 @@ CohortManifest <- R6::R6Class(
       on.exit(DBI::dbDisconnect(conn))
 
       active_count <- DBI::dbGetQuery(conn, "SELECT COUNT(*) as n FROM cohort_manifest WHERE status = 'active'")$n
+      stale_count <- DBI::dbGetQuery(conn, "SELECT COUNT(*) as n FROM cohort_manifest WHERE status = 'stale'")$n
       deleted_count <- DBI::dbGetQuery(conn, "SELECT COUNT(*) as n FROM cohort_manifest WHERE status = 'deleted'")$n
-      total_count <- active_count + deleted_count
+      # Stale cohorts are still registered — leaving them out of the total made
+      # the count appear to drop when a cohort was queued for regeneration
+      total_count <- active_count + stale_count + deleted_count
 
       cat("CohortManifest\n")
       cat("  Database:", private$.dbPath, "\n")
       cat("  Total cohorts: ", total_count, "\n", sep = "")
       cat("  Active: ", active_count, "\n", sep = "")
+      cat("  Stale: ", stale_count, "\n", sep = "")
       cat("  Deleted: ", deleted_count, "\n", sep = "")
 
       if (active_count > 0) {
@@ -3979,6 +4003,23 @@ CohortManifest <- R6::R6Class(
         if (active_count > 10) {
           cat("    ... and", active_count - 10, "more\n")
         }
+      }
+
+      # Stale cohorts are excluded from the active listing above, so name them
+      # here rather than letting them silently disappear from the printout
+      if (stale_count > 0) {
+        cat("\n  Stale cohorts (awaiting regeneration):\n")
+        stale <- DBI::dbGetQuery(
+          conn,
+          "SELECT id, label, category, source_type FROM cohort_manifest WHERE status = 'stale' ORDER BY id LIMIT 10"
+        )
+        for (i in seq_len(nrow(stale))) {
+          cat(sprintf("    [%d] %s (%s / %s)\n", stale$id[i], stale$label[i], stale$category[i], stale$source_type[i]))
+        }
+        if (stale_count > 10) {
+          cat("    ... and", stale_count - 10, "more\n")
+        }
+        cat("    Run generateCohorts() to regenerate them and return them to active.\n")
       }
 
       invisible(self)
@@ -5133,26 +5174,32 @@ CohortManifest <- R6::R6Class(
 
     #' @description Get summary status of manifest
     #'
-    #' @return List with elements: active_count, missing_count, deleted_count, next_available_id
+    #' @return List with elements: active_count, stale_count, missing_count,
+    #'   deleted_count, next_available_id
     getManifestStatus = function() {
       status_df <- self$validateManifest()
-      
+
       if (nrow(status_df) == 0) {
         return(list(
           active_count = 0L,
+          stale_count = 0L,
           missing_count = 0L,
           deleted_count = 0L,
           next_available_id = 1L
         ))
       }
-      
+
       active_count <- sum(status_df$status == "active", na.rm = TRUE)
-      missing_count <- sum(status_df$status == "active" & !status_df$file_exists, na.rm = TRUE)
+      # Stale cohorts are still registered and awaiting regeneration; counting
+      # them separately keeps them from disappearing out of every counter
+      stale_count <- sum(status_df$status == "stale", na.rm = TRUE)
+      missing_count <- sum(status_df$status %in% c("active", "stale") & !status_df$file_exists, na.rm = TRUE)
       deleted_count <- sum(status_df$status == "deleted", na.rm = TRUE)
       next_id <- max(status_df$id, na.rm = TRUE) + 1L
-      
+
       return(list(
         active_count = active_count,
+        stale_count = stale_count,
         missing_count = missing_count,
         deleted_count = deleted_count,
         next_available_id = next_id
@@ -5395,9 +5442,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildOPriorT = function(
       label,
@@ -5563,9 +5611,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildTPriorO = function(
       label,
@@ -5718,9 +5767,10 @@ CohortManifest <- R6::R6Class(
     #' @param stopIfExists Logical. If TRUE (default), raises an error when an
     #'   active or stale cohort with this label is already registered. If FALSE,
     #'   updates the registered derived cohort in place (same ID and file path):
-    #'   the SQL is re-rendered, parents and build parameters are replaced, the
-    #'   cohort is marked 'stale' for regeneration, and its own dependents are
-    #'   marked stale too. Default: TRUE (fail-safe).
+    #'   the SQL is re-rendered and parents and build parameters are replaced.
+    #'   When that changes the definition, the cohort is marked 'stale' for
+    #'   regeneration and its own dependents are marked stale too; an identical
+    #'   re-registration leaves the status untouched. Default: TRUE (fail-safe).
     #' @return Invisible integer. The assigned cohort ID.
     buildCensorCohort = function(
       label,

--- a/man/CohortManifest.Rd
+++ b/man/CohortManifest.Rd
@@ -661,9 +661,11 @@ Example: \.code{list(min_days = 30L, index_year = 2020L)}.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered cohort in place (same ID): the dependent cohort
-IDs/sqlParameters are re-rendered into the generated file, the cohort is
-marked 'stale' for regeneration, and its own dependents are marked stale
-too. Default: TRUE (fail-safe).}
+IDs/sqlParameters are re-rendered into the generated file. When that
+changes the definition, the cohort is marked 'stale' for regeneration
+and its own dependents are marked stale too; re-registering an
+identical definition leaves the status untouched.
+Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -770,9 +772,10 @@ Default: 0.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -847,9 +850,10 @@ qualifying events. Default: 'First'.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -914,9 +918,10 @@ in ALL exclude cohorts.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -982,9 +987,10 @@ to qualify for the composite. Default: 1 (any subject with at least 1 event qual
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -1051,9 +1057,10 @@ Common values: 8507 = Male, 8532 = Female. Default: NULL (all genders).}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -2034,7 +2041,8 @@ Get summary status of manifest
 }
 
 \subsection{Returns}{
-List with elements: active_count, missing_count, deleted_count, next_available_id
+List with elements: active_count, stale_count, missing_count,
+deleted_count, next_available_id
 }
 }
 \if{html}{\out{<hr>}}
@@ -2161,9 +2169,10 @@ Preferred route using manifest query results for the target cohort.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 
 \item{\code{keep_trace}}{Logical. If TRUE, marks missing as deleted with timestamp (soft delete).
 If FALSE, permanently removes from database (hard delete). Defaults to TRUE.}
@@ -2253,9 +2262,10 @@ Preferred route using manifest query results for the outcome cohort.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }
@@ -2321,9 +2331,10 @@ Preferred route using manifest query results for the censor cohort.}
 \item{\code{stopIfExists}}{Logical. If TRUE (default), raises an error when an
 active or stale cohort with this label is already registered. If FALSE,
 updates the registered derived cohort in place (same ID and file path):
-the SQL is re-rendered, parents and build parameters are replaced, the
-cohort is marked 'stale' for regeneration, and its own dependents are
-marked stale too. Default: TRUE (fail-safe).}
+the SQL is re-rendered and parents and build parameters are replaced.
+When that changes the definition, the cohort is marked 'stale' for
+regeneration and its own dependents are marked stale too; an identical
+re-registration leaves the status untouched. Default: TRUE (fail-safe).}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-CohortManifest-management.R
+++ b/tests/testthat/test-CohortManifest-management.R
@@ -66,8 +66,34 @@ testthat::test_that("getManifestStatus returns summary list", {
 
   out <- manifest$getManifestStatus()
 
-  testthat::expect_true(all(c("active_count", "missing_count", "deleted_count", "next_available_id") %in% names(out)))
+  testthat::expect_true(all(c("active_count", "stale_count", "missing_count", "deleted_count", "next_available_id") %in% names(out)))
   testthat::expect_true(out$active_count >= 5)
+  testthat::expect_equal(out$stale_count, 0)
+})
+
+# Testing: stale cohorts are still registered, so they must be counted and shown
+# rather than silently dropping out of the manifest summary and printout.
+testthat::test_that("stale cohorts stay in the manifest total and print listing", {
+  setup <- cm_test_seed_manifest_for_queries("mgmt-status-stale")
+  manifest <- setup$manifest
+
+  before <- manifest$getManifestStatus()
+  conn <- DBI::dbConnect(RSQLite::SQLite(), manifest$getDbPath())
+  DBI::dbExecute(conn, "UPDATE cohort_manifest SET status = 'stale' WHERE label = 'All-Cause Death'")
+  DBI::dbDisconnect(conn)
+
+  after <- manifest$getManifestStatus()
+  testthat::expect_equal(after$stale_count, 1)
+  testthat::expect_equal(after$active_count, before$active_count - 1)
+  testthat::expect_equal(
+    after$active_count + after$stale_count + after$deleted_count,
+    before$active_count + before$stale_count + before$deleted_count
+  )
+
+  printed <- paste(utils::capture.output(print(manifest)), collapse = "\n")
+  testthat::expect_match(printed, "Total cohorts: 5")
+  testthat::expect_match(printed, "Stale: 1")
+  testthat::expect_match(printed, "All-Cause Death")
 })
 
 # Testing: deleteCohort marks cohort status as deleted when confirmed.
@@ -434,6 +460,115 @@ testthat::test_that("addDependentCustomCohort stopIfExists FALSE updates deps an
   rule <- jsonlite::fromJSON(after$dependency_rule[[1]])
   testthat::expect_equal(as.integer(rule$dependentCohortIdList$inc_cohort_id), t2d_id)
   testthat::expect_equal(as.integer(rule$dependentCohortIdList$exc_cohort_id), ckd_id)
+})
+
+# Testing: re-registering an unchanged derived definition must not mark it stale,
+# which would drop it out of the active manifest and out of query results.
+testthat::test_that("addDependentCustomCohort re-run with identical args keeps cohort active", {
+  setup <- cm_test_new_manifest("mgmt-depcustom-rerun")
+  manifest <- setup$manifest
+
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Chronic Kidney Disease", fixture_name = "ckd.json")
+  cm_test_add_circe_cohort(manifest, setup$paths, label = "Type 2 Diabetes", fixture_name = "t2d.json")
+  rows <- manifest$tabulateManifest(filter = "active")
+  ckd_id <- as.integer(rows$id[rows$label == "Chronic Kidney Disease"][1])
+  t2d_id <- as.integer(rows$id[rows$label == "Type 2 Diabetes"][1])
+
+  dep_sql <- cm_test_sql_fixture_path("my_custom_dependent.sql")
+  register <- function(...) {
+    manifest$addDependentCustomCohort(
+      filePath = dep_sql,
+      label = "Dep Custom",
+      category = "Derived Cohorts",
+      dependentCohortIdList = list(inc_cohort_id = ckd_id, exc_cohort_id = t2d_id),
+      tags = list(owner = "epi_team"),
+      ...
+    )
+  }
+
+  dep_id <- as.integer(register())
+
+  # A downstream dependent must not be dragged stale by a no-op re-run either
+  downstream_parents <- manifest$queryCohortsByLabel(
+    labels = c("Dep Custom", "Type 2 Diabetes"),
+    matchType = "exact"
+  )
+  manifest$buildUnionCohort(
+    label = "Downstream_Union",
+    category = "Derived Cohorts",
+    cohortEntries = downstream_parents
+  )
+
+  returned_id <- as.integer(register(stopIfExists = FALSE))
+
+  after <- cm_test_get_manifest_row(manifest, "Dep Custom")
+  testthat::expect_equal(returned_id, dep_id)
+  testthat::expect_equal(after$status[[1]], "active")
+  testthat::expect_equal(cm_test_get_manifest_row(manifest, "Downstream_Union")$status[[1]], "active")
+
+  # Still visible in the active manifest and to label queries
+  active <- manifest$tabulateManifest(filter = "active")
+  testthat::expect_true("Dep Custom" %in% active$label)
+  testthat::expect_equal(
+    as.integer(manifest$queryCohortsByLabel("Dep Custom", matchType = "exact")$id[[1]]),
+    dep_id
+  )
+})
+
+# Testing: a metadata-only re-registration updates the metadata without forcing
+# regeneration of the cohort or its dependents.
+testthat::test_that("derived upsert with metadata-only change leaves status active", {
+  setup <- cm_test_seed_parent_with_union("mgmt-union-metadata-only")
+  manifest <- setup$manifest
+
+  before <- cm_test_get_manifest_row(manifest, "Capr_T2D_or_CKD")
+  testthat::expect_equal(before$status[[1]], "active")
+
+  parents <- manifest$queryCohortsByLabel(
+    labels = c("Capr T2D", "Chronic Kidney Disease"),
+    matchType = "exact"
+  )
+  manifest$buildUnionCohort(
+    label = "Capr_T2D_or_CKD",
+    category = "Recategorized",
+    cohortEntries = parents,
+    stopIfExists = FALSE
+  )
+
+  after <- cm_test_get_manifest_row(manifest, "Capr_T2D_or_CKD")
+  testthat::expect_equal(after$category[[1]], "Recategorized")
+  testthat::expect_equal(after$status[[1]], "active")
+  testthat::expect_equal(after$hash[[1]], before$hash[[1]])
+})
+
+# Testing: an already-stale cohort stays stale when re-registered unchanged —
+# the no-op path must not silently clear a pending regeneration.
+testthat::test_that("derived upsert with identical definition preserves existing stale status", {
+  setup <- cm_test_seed_parent_with_union("mgmt-union-stale-preserved")
+  manifest <- setup$manifest
+
+  union_row <- cm_test_get_manifest_row(manifest, "Capr_T2D_or_CKD")
+  conn <- DBI::dbConnect(RSQLite::SQLite(), manifest$getDbPath())
+  DBI::dbExecute(
+    conn,
+    "UPDATE cohort_manifest SET status = 'stale' WHERE id = ?",
+    list(as.integer(union_row$id[[1]]))
+  )
+  DBI::dbDisconnect(conn)
+
+  parents <- manifest$queryCohortsByLabel(
+    labels = c("Capr T2D", "Chronic Kidney Disease"),
+    matchType = "exact"
+  )
+  manifest$buildUnionCohort(
+    label = "Capr_T2D_or_CKD",
+    category = "Derived Cohorts",
+    cohortEntries = parents,
+    stopIfExists = FALSE
+  )
+
+  after <- cm_test_get_manifest_row(manifest, "Capr_T2D_or_CKD")
+  testthat::expect_equal(after$status[[1]], "stale")
 })
 
 # Testing: dependentCohortIdList entries accept vectors of IDs, stored in depends_on


### PR DESCRIPTION
Fixes a reported bug where re-running `$addDependentCustomCohort()` marked already-registered cohorts `stale` and made the total cohort count appear to drop (7 → 4 after 3 upserts). Two independent bugs; no data was lost — all rows stayed in SQLite with `deleted_at = NA` and every file remained on disk.

**1. No-op derived upserts marked cohorts stale.** `upsert_derived_cohort()` computed `definition_changed` but used it only to word the console message, always writing `status = 'stale'` and cascading. 

Staleness now cascades only on a real definition change (hash, file path, `depends_on`, `dependency_rule`). Metadata-only edits no longer force regeneration, and the no-op path leaves `status` untouched so an already-stale cohort stays stale.

**2. Stale cohorts counted in nothing.** `print()` totalled `active + deleted`, so stale cohorts fell in neither bucket and vanished from both the total and the listing. Independent of bug 1 — legitimately stale cohorts hit this too. The total now includes them, with their own `Stale:` line and listing. `getManifestStatus()` gains `stale_count`, and `missing_count` now covers stale rows.