### PR TITLE
Handle non-JSON tag columns in manifest parsing (#78)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 
 ## Bug Fixes
 
+- Manifest tag parsing no longer assumes the `tags` column holds a JSON string (see Issue #78). The `query*ByTagName()` methods default to `tags_format = "nested"`, which returns tags as a `tag_name`/`tag_value` tibble, so internal callers that re-parsed that column failed with `Argument 'txt' must be a JSON string, URL or file.` This broke `importAtlasCohorts()`/`importAtlasConceptSets()` (and therefore `sourceInputBuilderScripts()`), as well as `listAllUniqueTags()` and `getTagValuesSummary()`. Tag parsing now goes through a shared helper that accepts JSON strings, nested tibbles, and already-parsed lists, and treats missing/empty/malformed tags as no tags.
 - add `$queryConceptSetsByCategory()` it was missing
 - add `stopIfExists` option to ATLAS csv load builders (see Issue #65)
 - Custom dependent cohort builder is now consistent with the other dependent cohort builders - the rendered SQL query is written to the file system, and it accepts cohort objects as inputs instead of IDs. 

--- a/R/CohortManifest.R
+++ b/R/CohortManifest.R
@@ -1124,13 +1124,10 @@ CohortManifest <- R6::R6Class(
         man <- man |>
           dplyr::mutate(
             tags = purrr::map(tags, function(tags_json) {
-              if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-                return(tibble::tibble(tag_name = character(0), tag_value = character(0)))
-              }
-              parsed_tags <- jsonlite::fromJSON(tags_json)
+              parsed_tags <- safe_parse_tags(tags_json)
               tibble::tibble(
-                tag_name = names(parsed_tags),
-                tag_value = as.character(unlist(parsed_tags))
+                tag_name = names(parsed_tags) %||% character(0),
+                tag_value = as.character(unlist(parsed_tags) %||% character(0))
               )
             })
           )
@@ -1139,12 +1136,7 @@ CohortManifest <- R6::R6Class(
         # Expand tags into wide format (one column per tag key)
         man <- man |>
           dplyr::mutate(
-            tags_list = purrr::map(tags, function(tags_json) {
-              if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-                return(list())
-              }
-              jsonlite::fromJSON(tags_json)
-            })
+            tags_list = purrr::map(tags, safe_parse_tags)
           ) |>
           tidyr::unnest_wider(tags_list, names_sep = "_") |>
           dplyr::select(-tags)
@@ -1345,10 +1337,7 @@ CohortManifest <- R6::R6Class(
 
           # Identity guard: the registered cohort must be the same ATLAS cohort,
           # otherwise this is almost certainly an accidental label collision
-          registered_tags <- tryCatch(
-            jsonlite::fromJSON(existing$tags[1]),
-            error = function(e) NULL
-          )
+          registered_tags <- safe_parse_tags(existing$tags[1])
           registered_atlas_id <- registered_tags$atlasId
           if (is.null(registered_atlas_id)) {
             cli::cli_abort(c(
@@ -1519,7 +1508,7 @@ CohortManifest <- R6::R6Class(
       }
 
       # Determine which cohorts are new and need to be loaded
-      cm_atlas_subset <- self$queryCohortsByTagName(tagName = "atlasId")
+      cm_atlas_subset <- self$queryCohortsByTagName(tagName = "atlasId", tags_format = "json")
       cohort_load_2 <- check_which_atlas_exist(cm_atlas_subset, cohortsLoad)
 
       # Header
@@ -2855,8 +2844,8 @@ CohortManifest <- R6::R6Class(
     #'
     #' @param ids Integer vector. One or more cohort IDs.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -2890,8 +2879,8 @@ CohortManifest <- R6::R6Class(
     #' @param match Character. "any" (default) returns cohorts matching at least one tag;
     #'   "all" returns only cohorts matching every tag.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -2922,12 +2911,7 @@ CohortManifest <- R6::R6Class(
 
       manifest_df <- manifest_df |>
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         )
 
       tag_match <- purrr::map_lgl(manifest_df$tags_list, function(cohort_tags) {
@@ -2964,8 +2948,8 @@ CohortManifest <- R6::R6Class(
     #' @param matchType Character. Either "exact" for exact match or "pattern" for pattern matching.
     #'   Defaults to "exact".
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -3014,8 +2998,8 @@ CohortManifest <- R6::R6Class(
     #' @param matchType Character. Either "exact" for exact match or "pattern" for pattern matching.
     #'   Defaults to "exact".
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -3061,8 +3045,8 @@ CohortManifest <- R6::R6Class(
     #'
     #' @param tagName Character vector. The name of tags to query.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -3073,12 +3057,7 @@ CohortManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest(filter = "active", tags_format = "json") |> 
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         ) |>
         dplyr::filter(
           purrr::map_lgl(.data$tags_list, ~any(tagName %in% names(.)))
@@ -3097,8 +3076,8 @@ CohortManifest <- R6::R6Class(
     #'
     #' @param tagName Character. The name of the tag to check for absence.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -3110,12 +3089,7 @@ CohortManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest(filter = "active", tags_format = "json") |>
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         ) |>
         dplyr::filter(
           !purrr::map_lgl(.data$tags_list, ~tagName %in% names(.))
@@ -3140,8 +3114,8 @@ CohortManifest <- R6::R6Class(
     #' @param tagValueMapping Named list. Keys are tag names, values are tag values to match.
     #'   Example: \code{list(status = "approved", type = "primary")} requires both conditions (AND logic).
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching cohorts. Tag columns depend on
@@ -3175,8 +3149,7 @@ CohortManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest() |>
         dplyr::mutate(
-          tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x)),
-          tag_value = purrr::map_chr(tags_list, ~.x[[tagName]] %||% NA_character_)
+          tag_value = purrr::map_chr(tags, ~as.character(safe_tag_value(.x, tagName)))
         ) |>
         dplyr::filter(!is.na(tag_value)) |>
         dplyr::group_by(tag_value) |>
@@ -3375,7 +3348,7 @@ CohortManifest <- R6::R6Class(
       }
 
       # Parse tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Check if tag exists
       if (!tagName %in% names(current_tags)) {
@@ -3419,7 +3392,7 @@ CohortManifest <- R6::R6Class(
       }
 
       # Parse tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Check if tag exists
       if (!tagName %in% names(current_tags)) {
@@ -3465,7 +3438,7 @@ CohortManifest <- R6::R6Class(
       }
 
       # Parse existing tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Add new tag (overwrites if already exists)
       current_tags[[tagName]] <- tagValue
@@ -3498,7 +3471,7 @@ CohortManifest <- R6::R6Class(
         return(NULL)
       }
 
-      jsonlite::fromJSON(current_tags_json$tags[1])
+      safe_parse_tags(current_tags_json$tags[1])
     },
 
     #' @description Merge multiple tags into a cohort (non-destructive, additive)
@@ -3525,7 +3498,7 @@ CohortManifest <- R6::R6Class(
       }
 
       # Parse and merge
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
       merged_tags <- c(current_tags, newTags)  # Vector merge adds/overwrites
 
       # Update using existing method
@@ -3548,7 +3521,7 @@ CohortManifest <- R6::R6Class(
 
       # Extract all unique tag names
       all_tag_names <- manifest_tbl |>
-        dplyr::mutate(tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x))) |>
+        dplyr::mutate(tags_list = purrr::map(tags, safe_parse_tags)) |>
         dplyr::pull(tags_list) |>
         purrr::map(names) |>
         unlist() |>
@@ -3734,8 +3707,9 @@ CohortManifest <- R6::R6Class(
 
       cm_atlas_subset <- self$queryCohortsByTagName(tagName = "atlasId", tags_format = "json") |>
         dplyr::mutate(
-          tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x)),
-          atlasId = purrr::map_int(tags_list, ~.x$atlasId)
+          atlasId = purrr::map_int(tags, ~suppressWarnings(
+            as.integer(safe_tag_value(.x, "atlasId", default = NA_integer_))
+          ))
         ) |>
         dplyr::select(
           id, atlasId, label, category, hash, file_path

--- a/R/ConceptSetManifest.R
+++ b/R/ConceptSetManifest.R
@@ -504,13 +504,10 @@ ConceptSetManifest <- R6::R6Class(
         man <- man |>
           dplyr::mutate(
             tags = purrr::map(tags, function(tags_json) {
-              if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-                return(tibble::tibble(tag_name = character(0), tag_value = character(0)))
-              }
-              parsed_tags <- jsonlite::fromJSON(tags_json)
+              parsed_tags <- safe_parse_tags(tags_json)
               tibble::tibble(
-                tag_name = names(parsed_tags),
-                tag_value = as.character(unlist(parsed_tags))
+                tag_name = names(parsed_tags) %||% character(0),
+                tag_value = as.character(unlist(parsed_tags) %||% character(0))
               )
             })
           )
@@ -519,12 +516,7 @@ ConceptSetManifest <- R6::R6Class(
         # Expand tags into wide format (one column per tag key)
         man <- man |>
           dplyr::mutate(
-            tags_list = purrr::map(tags, function(tags_json) {
-              if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-                return(list())
-              }
-              jsonlite::fromJSON(tags_json)
-            })
+            tags_list = purrr::map(tags, safe_parse_tags)
           ) |>
           tidyr::unnest_wider(tags_list, names_sep = "_") |>
           dplyr::select(-tags)
@@ -701,10 +693,7 @@ ConceptSetManifest <- R6::R6Class(
         # Identity guard: the registered concept set must be the same ATLAS
         # concept set, otherwise this is almost certainly an accidental
         # label collision
-        registered_tags <- tryCatch(
-          jsonlite::fromJSON(existing$tags[1]),
-          error = function(e) NULL
-        )
+        registered_tags <- safe_parse_tags(existing$tags[1])
         registered_atlas_id <- registered_tags$atlasId
         if (is.null(registered_atlas_id)) {
           cli::cli_abort(c(
@@ -947,10 +936,7 @@ ConceptSetManifest <- R6::R6Class(
 
       # Ownership guard: an ATLAS-registered concept set must not be silently
       # clobbered by a Capr update under a reused label
-      registered_tags <- tryCatch(
-        jsonlite::fromJSON(existing$tags[1]),
-        error = function(e) NULL
-      )
+      registered_tags <- safe_parse_tags(existing$tags[1])
       if (!is.null(registered_tags$atlasId)) {
         cli::cli_abort(c(
           "Concept set {.val {label}} (ID {existing$id[1]}) is registered from ATLAS (atlasId {registered_tags$atlasId}).",
@@ -1043,7 +1029,7 @@ ConceptSetManifest <- R6::R6Class(
       }
 
       # Determine which concept sets are new and which already exist
-      cm_atlas_subset <- self$queryConceptSetsByTagName(tagName = "atlasId")
+      cm_atlas_subset <- self$queryConceptSetsByTagName(tagName = "atlasId", tags_format = "json")
       concept_set_load_2 <- check_which_atlas_exist(cm_atlas_subset, conceptSetsLoad)
 
       # Header
@@ -1149,8 +1135,8 @@ ConceptSetManifest <- R6::R6Class(
     #'
     #' @param ids Integer vector. One or more concept set IDs.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1184,8 +1170,8 @@ ConceptSetManifest <- R6::R6Class(
     #' @param match Character. "any" (default) returns concept sets matching at least one tag;
     #'   "all" returns only concept sets matching every tag.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1216,12 +1202,7 @@ ConceptSetManifest <- R6::R6Class(
 
       manifest_df <- manifest_df |>
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         )
 
       tag_match <- purrr::map_lgl(manifest_df$tags_list, function(cs_tags) {
@@ -1257,8 +1238,8 @@ ConceptSetManifest <- R6::R6Class(
     #' @param matchType Character. Either "exact" for exact match or "pattern" for pattern matching.
     #'   Defaults to "exact".
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1304,8 +1285,8 @@ ConceptSetManifest <- R6::R6Class(
     #'
     #' @param tagName Character vector. The name of tags to query.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1316,12 +1297,7 @@ ConceptSetManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest(filter = "active", tags_format = "json") |> 
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         ) |>
         dplyr::filter(
           purrr::map_lgl(.data$tags_list, ~any(tagName %in% names(.)))
@@ -1340,8 +1316,8 @@ ConceptSetManifest <- R6::R6Class(
     #'
     #' @param tagName Character. The name of the tag to check for absence.
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1353,12 +1329,7 @@ ConceptSetManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest(filter = "active", tags_format = "json") |>
         dplyr::mutate(
-          tags_list = purrr::map(.data$tags, function(tags_json) {
-            if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-              return(list())
-            }
-            jsonlite::fromJSON(tags_json)
-          })
+          tags_list = purrr::map(.data$tags, safe_parse_tags)
         ) |>
         dplyr::filter(
           !purrr::map_lgl(.data$tags_list, ~tagName %in% names(.))
@@ -1383,8 +1354,8 @@ ConceptSetManifest <- R6::R6Class(
     #' @param tagValueMapping Named list. Keys are tag names, values are tag values to match.
     #'   Example: \code{list(status = "approved", type = "primary")} requires both conditions (AND logic).
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1418,8 +1389,7 @@ ConceptSetManifest <- R6::R6Class(
 
       tcm <- self$tabulateManifest() |>
         dplyr::mutate(
-          tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x)),
-          tag_value = purrr::map_chr(tags_list, ~.x[[tagName]] %||% NA_character_)
+          tag_value = purrr::map_chr(tags, ~as.character(safe_tag_value(.x, tagName)))
         ) |>
         dplyr::filter(!is.na(tag_value)) |>
         dplyr::group_by(tag_value) |>
@@ -1446,8 +1416,8 @@ ConceptSetManifest <- R6::R6Class(
     #' @param matchType Character. Either "exact" for exact match or "pattern" for pattern matching.
     #'   Defaults to "exact".
     #' @param tags_format Character. One of "nested", "json", or "wide".
-    #'   - "nested": Tags as nested tibble with tag_name/tag_value columns
-    #'   - "json" (default): Tags as raw JSON string
+    #'   - "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+    #'   - "json": Tags as raw JSON string
     #'   - "wide": Tags expanded into individual columns
     #'
     #' @return Tibble with matching concept sets. Tag columns depend on
@@ -1933,7 +1903,7 @@ ConceptSetManifest <- R6::R6Class(
       }
 
       # Parse tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Check if tag exists
       if (!tagName %in% names(current_tags)) {
@@ -1977,7 +1947,7 @@ ConceptSetManifest <- R6::R6Class(
       }
 
       # Parse tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Check if tag exists
       if (!tagName %in% names(current_tags)) {
@@ -2023,7 +1993,7 @@ ConceptSetManifest <- R6::R6Class(
       }
 
       # Parse existing tags
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
 
       # Add new tag (overwrites if already exists)
       current_tags[[tagName]] <- tagValue
@@ -2056,7 +2026,7 @@ ConceptSetManifest <- R6::R6Class(
         return(NULL)
       }
 
-      jsonlite::fromJSON(current_tags_json$tags[1])
+      safe_parse_tags(current_tags_json$tags[1])
     },
 
     #' @description Merge multiple tags into a concept set (non-destructive, additive)
@@ -2083,7 +2053,7 @@ ConceptSetManifest <- R6::R6Class(
       }
 
       # Parse and merge
-      current_tags <- jsonlite::fromJSON(current_tags_json$tags[1])
+      current_tags <- safe_parse_tags(current_tags_json$tags[1])
       merged_tags <- c(current_tags, newTags)  # Vector merge adds/overwrites
 
       # Update using existing method
@@ -2106,7 +2076,7 @@ ConceptSetManifest <- R6::R6Class(
 
       # Extract all unique tag names
       all_tag_names <- manifest_tbl |>
-        dplyr::mutate(tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x))) |>
+        dplyr::mutate(tags_list = purrr::map(tags, safe_parse_tags)) |>
         dplyr::pull(tags_list) |>
         purrr::map(names) |>
         unlist() |>
@@ -2293,8 +2263,9 @@ ConceptSetManifest <- R6::R6Class(
       # Query for concept sets with atlasId tag
       atlas_subset <- self$queryConceptSetsByTagName(tagName = "atlasId", tags_format = "json") |>
         dplyr::mutate(
-          tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x)),
-          atlasId = purrr::map_int(tags_list, ~.x$atlasId)
+          atlasId = purrr::map_int(tags, ~suppressWarnings(
+            as.integer(safe_tag_value(.x, "atlasId", default = NA_integer_))
+          ))
         ) |>
         dplyr::select(
           id, atlasId, label, category, hash, file_path

--- a/R/manifest_helpers.R
+++ b/R/manifest_helpers.R
@@ -1298,6 +1298,69 @@ cascadeStaleDownstream <- function(dbPath, cohort_ids) {
   invisible(visited)
 }
 
+#' Parse a manifest tags value into a named list
+#'
+#' Manifest tags are stored in sqlite as a JSON string, but they reach calling
+#' code in several shapes: the raw JSON string (`tags_format = "json"`), a
+#' nested `tag_name`/`tag_value` tibble (`tags_format = "nested"`, the default
+#' for `tabulateManifest()` and the `query*()` methods), or an already-parsed
+#' list. `safe_parse_tags()` normalises any of those to a named list so tag
+#' handling never depends on which format it was handed.
+#'
+#' @param tags A JSON string, a named list, or a `tag_name`/`tag_value` data
+#'   frame. `NULL`, `NA`, empty strings, and unparseable JSON all yield
+#'   `list()`.
+#'
+#' @return A named list of tag values.
+#' @noRd
+safe_parse_tags <- function(tags) {
+  if (is.null(tags) || length(tags) == 0) {
+    return(list())
+  }
+
+  # "nested" format: one row per tag
+  if (is.data.frame(tags)) {
+    if (nrow(tags) == 0 || !all(c("tag_name", "tag_value") %in% names(tags))) {
+      return(list())
+    }
+    return(stats::setNames(as.list(tags$tag_value), as.character(tags$tag_name)))
+  }
+
+  # Already parsed
+  if (is.list(tags)) {
+    return(as.list(tags))
+  }
+
+  tags <- as.character(tags)
+  if (length(tags) != 1L || is.na(tags) || !nzchar(trimws(tags))) {
+    return(list())
+  }
+
+  parsed <- tryCatch(jsonlite::fromJSON(tags), error = function(e) NULL)
+  if (is.null(parsed) || length(parsed) == 0) {
+    return(list())
+  }
+
+  as.list(parsed)
+}
+
+#' Pull a single tag value out of a manifest tags value
+#'
+#' @param tags Anything `safe_parse_tags()` accepts.
+#' @param tagName Character. Name of the tag to extract.
+#' @param default Value returned when the tag is absent or empty.
+#'
+#' @return The first value stored under `tagName`, or `default`.
+#' @noRd
+safe_tag_value <- function(tags, tagName, default = NA_character_) {
+  parsed <- safe_parse_tags(tags)
+  value <- parsed[[tagName]]
+  if (is.null(value) || length(value) == 0 || all(is.na(value))) {
+    return(default)
+  }
+  value[[1]]
+}
+
 list_tags_in_row <- function(row) {
   reserved_cols <- c("atlasId","label", "category", "file_name") # file_name is legacy
   tag_cols <- setdiff(names(row), reserved_cols)
@@ -1318,8 +1381,9 @@ check_which_atlas_exist <- function(atlas_subset, input_load) {
       id, label, category, tags
     ) |> 
     dplyr::mutate(
-      tags_list = purrr::map(tags, ~jsonlite::fromJSON(.x)),
-      atlasId = purrr::map_int(tags_list, ~.x$atlasId),
+      atlasId = purrr::map_int(tags, ~suppressWarnings(
+        as.integer(safe_tag_value(.x, "atlasId", default = NA_integer_))
+      )),
       status = "active"
     ) |>
     dplyr::select(
@@ -1338,17 +1402,12 @@ check_which_atlas_exist <- function(atlas_subset, input_load) {
 
 
 jsonToStingTags <- function(tags_json, tag_delimiter) {
-  if (is.na(tags_json) || is.null(tags_json) || tags_json == "") {
-    rr <- ""
-    return(rr)
-  }
-  
-  parsed_tags <- jsonlite::fromJSON(tags_json)
+  parsed_tags <- safe_parse_tags(tags_json)
   if (length(parsed_tags) == 0) {
     rr <- ""
     return(rr)
   }
-  
+
   tag_values <- as.character(unlist(parsed_tags, use.names = FALSE))
   tag_names <- names(parsed_tags)
   

--- a/man/CohortManifest.Rd
+++ b/man/CohortManifest.Rd
@@ -258,7 +258,7 @@ for exploring manifest contents without console clutter.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{CohortManifest$viewManifest(
   filter = c("active", "deleted", "stale", "all"),
-  tags_format = c("nested", "json", "wide")
+  tagDelimiter = " | "
 )}\if{html}{\out{</div>}}
 }
 
@@ -268,12 +268,7 @@ for exploring manifest contents without console clutter.
 \item{\code{filter}}{Character. One of "active", "deleted", "stale", or "all".
 Defaults to "active".}
 
-\item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
-\itemize{
-\item "nested" (default): Tags as structured nested tibble
-\item "json": Tags as raw JSON string
-\item "wide": Tags expanded into individual columns
-}}
+\item{\code{tagDelimiter}}{a character used to seperate tags in the view. Default is |}
 }
 \if{html}{\out{</div>}}
 }
@@ -1135,8 +1130,8 @@ Query cohorts by IDs
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1172,8 +1167,8 @@ argument controls whether a cohort must satisfy any or all of them.}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1208,8 +1203,8 @@ Defaults to "exact".}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1244,8 +1239,8 @@ Defaults to "exact".}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1275,8 +1270,8 @@ Query cohorts by category
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1306,8 +1301,8 @@ Query cohorts missing a specific tag
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1338,8 +1333,8 @@ Example: \code{list(status = "approved", type = "primary")} requires both condit
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }

--- a/man/ConceptSetManifest.Rd
+++ b/man/ConceptSetManifest.Rd
@@ -70,7 +70,8 @@ this method to apply updates.
 
 \strong{Processing:}
 \enumerate{
-\item Retrieves the concept set definition (CIRCE JSON) by ID
+\item Resolves the concept set by manifest ID or exact label
+\item Retrieves the concept set definition (CIRCE JSON)
 \item Builds SQL query using \code{CirceR::buildConceptSetQuery()}
 \item Executes query against the OMOP vocabulary schema
 \item Returns results with concept_id and concept_name columns
@@ -595,8 +596,8 @@ Query concept sets by IDs
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -632,8 +633,8 @@ argument controls whether a concept set must satisfy any or all of them.}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -668,8 +669,8 @@ Defaults to "exact".}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -699,8 +700,8 @@ Query concept sets by tag name
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -730,8 +731,8 @@ Query concept sets missing a specific tag
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -762,8 +763,8 @@ Example: \code{list(status = "approved", type = "primary")} requires both condit
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -819,8 +820,8 @@ Defaults to "exact".}
 
 \item{\code{tags_format}}{Character. One of "nested", "json", or "wide".
 \itemize{
-\item "nested": Tags as nested tibble with tag_name/tag_value columns
-\item "json" (default): Tags as raw JSON string
+\item "nested" (default): Tags as nested tibble with tag_name/tag_value columns
+\item "json": Tags as raw JSON string
 \item "wide": Tags expanded into individual columns
 }}
 }
@@ -1389,13 +1390,15 @@ The concept set definition (stored as CIRCE JSON) is used to build a query that 
 all concept IDs and names matching the set definition. Results are returned as a tibble
 with concept identifiers and display names.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ConceptSetManifest$grabConceptInfoFromSet(conceptSetId)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ConceptSetManifest$grabConceptInfoFromSet(conceptSetRef)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{conceptSetId}}{Integer. The concept set ID in the manifest.}
+\item{\code{conceptSetRef}}{Integer or Character. Concept set reference in the
+manifest. Pass either the manifest ID or the exact concept set label.
+Use \code{tabulateManifest()} to inspect available IDs and labels.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ExecutionSettings.Rd
+++ b/man/ExecutionSettings.Rd
@@ -29,6 +29,7 @@ An R6 class to define an ExecutionSettings object
 \item \href{#method-ExecutionSettings-connect}{\code{ExecutionSettings$connect()}}
 \item \href{#method-ExecutionSettings-disconnect}{\code{ExecutionSettings$disconnect()}}
 \item \href{#method-ExecutionSettings-getConnection}{\code{ExecutionSettings$getConnection()}}
+\item \href{#method-ExecutionSettings-reviewConnectionDetails}{\code{ExecutionSettings$reviewConnectionDetails()}}
 \item \href{#method-ExecutionSettings-clone}{\code{ExecutionSettings$clone()}}
 }
 }
@@ -137,6 +138,19 @@ with an informative message. Use this to check connection status before database
 
 \subsection{Returns}{
 DatabaseConnectorJdbcConnection or NULL
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ExecutionSettings-reviewConnectionDetails"></a>}}
+\if{latex}{\out{\hypertarget{method-ExecutionSettings-reviewConnectionDetails}{}}}
+\subsection{Method \code{reviewConnectionDetails()}}{
+Return the configured connectionDetails object
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ExecutionSettings$reviewConnectionDetails()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+A DatabaseConnector connectionDetails object or NULL.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/importAndBind.Rd
+++ b/man/importAndBind.Rd
@@ -49,4 +49,5 @@ Folder structure expected:
 }\if{html}{\out{</div>}}
 
 All files with the same name from each database are combined with databaseId added and saved to exportPath.
+Exported filenames are prefixed with the task sequence from \code{taskName} (e.g., \verb{01_results.csv}) to avoid collisions across tasks.
 }

--- a/tests/testthat/test-CohortManifest-tags.R
+++ b/tests/testthat/test-CohortManifest-tags.R
@@ -460,3 +460,126 @@ testthat::test_that("Tag discovery and audit workflow", {
   testthat::expect_equal(nrow(enum_summary), 1)
   testthat::expect_equal(enum_summary$count[[1]], 2)
 })
+
+# ============================================================================
+# Tag Parsing Robustness (issue #78)
+# ============================================================================
+
+# Testing: safe_parse_tags accepts every shape a `tags` column can arrive in.
+testthat::test_that("safe_parse_tags normalises all tag representations", {
+  # Raw JSON string, as stored in sqlite
+  testthat::expect_equal(
+    safe_parse_tags('{"atlasId":123,"owner":"alice"}'),
+    list(atlasId = 123L, owner = "alice")
+  )
+
+  # "nested" tags_format: a tag_name/tag_value tibble
+  nested <- tibble::tibble(
+    tag_name = c("atlasId", "owner"),
+    tag_value = c("123", "alice")
+  )
+  testthat::expect_equal(
+    safe_parse_tags(nested),
+    list(atlasId = "123", owner = "alice")
+  )
+
+  # Already-parsed list passes through
+  testthat::expect_equal(
+    safe_parse_tags(list(owner = "alice")),
+    list(owner = "alice")
+  )
+
+  # Factors are coerced rather than rejected
+  testthat::expect_equal(
+    safe_parse_tags(factor('{"owner":"alice"}')),
+    list(owner = "alice")
+  )
+
+  # Empty / missing / malformed inputs degrade to an empty list
+  testthat::expect_equal(safe_parse_tags(NULL), list())
+  testthat::expect_equal(safe_parse_tags(NA), list())
+  testthat::expect_equal(safe_parse_tags(NA_character_), list())
+  testthat::expect_equal(safe_parse_tags(""), list())
+  testthat::expect_equal(safe_parse_tags("not json"), list())
+  testthat::expect_equal(
+    safe_parse_tags(tibble::tibble(tag_name = character(0), tag_value = character(0))),
+    list()
+  )
+})
+
+# Testing: safe_tag_value pulls a single tag out regardless of input shape.
+testthat::test_that("safe_tag_value extracts a tag from any representation", {
+  nested <- tibble::tibble(tag_name = "atlasId", tag_value = "123")
+
+  testthat::expect_equal(safe_tag_value('{"atlasId":123}', "atlasId"), 123L)
+  testthat::expect_equal(safe_tag_value(nested, "atlasId"), "123")
+  testthat::expect_true(is.na(safe_tag_value('{"owner":"alice"}', "atlasId")))
+  testthat::expect_equal(
+    safe_tag_value(NA, "atlasId", default = NA_integer_),
+    NA_integer_
+  )
+})
+
+# Testing: check_which_atlas_exist is the shared helper behind the ATLAS import
+# paths. It previously assumed `tags` was JSON and errored with
+# "Argument 'txt' must be a JSON string" when handed the nested tibble that
+# query*ByTagName() returns by default.
+testthat::test_that("check_which_atlas_exist handles json and nested tag columns", {
+  load_df <- tibble::tibble(
+    atlasId = c(123L, 456L),
+    label = c("Registered", "Brand New"),
+    category = c("Test", "Test")
+  )
+
+  json_subset <- tibble::tibble(
+    id = 1L,
+    label = "Registered",
+    category = "Test",
+    tags = '{"atlasId":123}'
+  )
+
+  nested_subset <- tibble::tibble(
+    id = 1L,
+    label = "Registered",
+    category = "Test",
+    tags = list(tibble::tibble(tag_name = "atlasId", tag_value = "123"))
+  )
+
+  for (subset in list(json_subset, nested_subset)) {
+    res <- check_which_atlas_exist(subset, load_df)
+    testthat::expect_equal(res$status, c("active", "new"))
+    testthat::expect_equal(res$id, c(1L, NA_integer_))
+  }
+})
+
+# Testing: an empty manifest (no ATLAS cohorts registered yet) must not error —
+# every load row is simply "new".
+testthat::test_that("check_which_atlas_exist tolerates an empty manifest subset", {
+  empty_subset <- tibble::tibble(
+    id = integer(0),
+    label = character(0),
+    category = character(0),
+    tags = character(0)
+  )
+  load_df <- tibble::tibble(atlasId = 123L, label = "New", category = "Test")
+
+  res <- check_which_atlas_exist(empty_subset, load_df)
+  testthat::expect_equal(res$status, "new")
+})
+
+# Testing: tag summaries read the manifest with its default ("nested") tags
+# format, so they must not assume the column holds JSON strings.
+testthat::test_that("tag summaries work over the default nested tags format", {
+  setup <- cm_test_seed_manifest_for_queries("tags-nested-summaries")
+  manifest <- setup$manifest
+
+  row <- manifest$queryCohortsByLabel("Type 2 Diabetes", matchType = "exact")
+  cohort_id <- as.integer(row$id[[1]])
+  manifest$addCohortTag(cohort_id, "reviewer", "alice")
+
+  testthat::expect_true("reviewer" %in% manifest$listAllUniqueTags())
+
+  summary_tbl <- manifest$getTagValuesSummary("reviewer")
+  testthat::expect_equal(summary_tbl$value, "alice")
+  testthat::expect_equal(summary_tbl$count, 1L)
+})


### PR DESCRIPTION
Fixes #78.

## Root cause

`tabulateManifest()` and the `query*()` methods take `tags_format = c("nested", "json", "wide")`, so `match.arg()` makes **`"nested"`** the default — the `tags` column comes back as a `tag_name`/`tag_value` tibble, not the JSON string stored in sqlite.

Several call sites then re-parsed that column with `jsonlite::fromJSON()`, which aborts with:

```
Argument 'txt' must be a JSON string, URL or file.
```

The concrete break in the issue is `check_which_atlas_exist()` (`R/manifest_helpers.R`), reached from `importAtlasConceptSets()` and `importAtlasCohorts()` — and therefore from any `sourceInputBuilderScripts()` run whose builders call them:

```r
cm_atlas_subset <- self$queryConceptSetsByTagName(tagName = "atlasId")  # -> nested
concept_set_load_2 <- check_which_atlas_exist(cm_atlas_subset, conceptSetsLoad)  # -> fromJSON(tibble)
```

`listAllUniqueTags()` and `getTagValuesSummary()` were broken the same way in both manifest classes (they call `self$tabulateManifest()` with no format). Those were already failing in the existing test suite on `develop`.

## Changes

- **`safe_parse_tags()` / `safe_tag_value()`** (`R/manifest_helpers.R`, internal). Normalise a JSON string, a nested `tag_name`/`tag_value` tibble, or an already-parsed list to a named list; `NULL`/`NA`/empty/malformed input degrades to `list()`.
- Route every manifest tag parse through them, collapsing ~15 copies of the same inline `fromJSON()` parser. Side benefit: a cohort or concept set with no tags no longer errors in `getCohortTags()` / `getConceptSetTags()`.
- Fix the root cause directly too — the ATLAS import and update paths now ask for `tags_format = "json"` explicitly, and coerce the `atlasId` tag instead of assuming it comes back as an integer.
- Correct the roxygen for the `query*()` methods, which advertised `"json" (default)` when `match.arg()` selects `"nested"`.

This follows the suggestion in the issue, with two additions: fixing the callers that requested the wrong format in the first place, so the defensive parser isn't load-bearing, and correcting the misleading docs.

## Tests

New regression tests in `tests/testthat/test-CohortManifest-tags.R` cover `safe_parse_tags()` / `safe_tag_value()` across all input shapes, `check_which_atlas_exist()` with both `json` and `nested` tag columns (and an empty manifest), and tag summaries over the default nested format.

Full suite: **10 failures before → 4 after**. All 4 remaining were verified to reproduce on unmodified `develop` and are unrelated (`addCaprCohort` source_type `capr` vs `circe`, a `getCohortsByLabel` regex assertion, and a `makePrintFriendlyFile` fixture-directory issue).

Also regenerates `man/ExecutionSettings.Rd` and `man/importAndBind.Rd`, which were stale on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)