### PR TITLE
Fix dissemination bugs (#87)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,10 @@
 - Custom dependent cohort builder now also allows user to specify non-cohort-ID params, so the rendered SQL query can be generated in a single function call (see Issue #66)
 - Builder console messages clarified (see Issue #70)
 - on `resetManifest` turn archive default to FALSE
+- Fixed two dissemination bugs (see Issue #87):
+  - `prepareDisseminationData()` asserted that four concatenated logical flags had length 1, so it aborted on every call — including all-default calls — and the formatting step could never run.
+  - The dissemination script template checked merged results for a `database_id` column, but `importAndBind()` labels them with camelCase `databaseId`, so the check was always false. The later references to `database_id` are correct, as they operate on data already passed through `cleanColumnNames()`.
+- `standardizeDataTypes()` no longer discards columns it cannot coerce. The default `"_id$"` rule matched the character `database_id` column and `as.integer()` silently turned it into `NA`, since failed coercion raises a warning rather than an error. A conversion that would turn a non-missing value into `NA` is now skipped and reported.
 - Refactor `query...Manifest` methods to use `$tabulateManifest()` internally to be more consistent. 
 - Show current manifest id after import (see Issue #68)
 - remove function forced tags `route = atlas` or `route = capr` (See Issue #67)

--- a/R/disseminate.R
+++ b/R/disseminate.R
@@ -133,6 +133,19 @@ formatFloats <- function(data, float_cols = NULL, decimal_places = 2, remove_tra
   return(data)
 }
 
+# Coerce a single column to a target type. Unknown types are returned
+# untouched so an unrecognised rule is a no-op rather than an error.
+coerce_column <- function(x, target_type) {
+  switch(target_type,
+    integer = as.integer(x),
+    numeric = as.numeric(x),
+    character = as.character(x),
+    logical = as.logical(x),
+    date = as.Date(x),
+    x
+  )
+}
+
 #' Standardize Data Types
 #' @description Standardizes data types across columns based on common patterns
 #'   (e.g., columns ending in "_id" become integers, columns with "date" become dates).
@@ -149,6 +162,10 @@ formatFloats <- function(data, float_cols = NULL, decimal_places = 2, remove_tra
 #' - Columns named "*_date": convert to date (ISO format assumed)
 #' - Columns named "*_count": convert to integer
 #' - Columns containing "flag" or "indicator": convert to logical
+#'
+#' A conversion is only applied if it preserves every non-missing value. A
+#' column that matches a rule but cannot be coerced without introducing `NA`
+#' (for example a character `database_id`) is left as-is and reported.
 #'
 standardizeDataTypes <- function(data, type_rules = NULL) {
   checkmate::assert_data_frame(data)
@@ -170,21 +187,29 @@ standardizeDataTypes <- function(data, type_rules = NULL) {
       matching_cols <- colnames(data)[grepl(pattern, tolower(colnames(data)))]
 
       for (col in matching_cols) {
-        tryCatch({
-          if (target_type == "integer") {
-            data[[col]] <- as.integer(data[[col]])
-          } else if (target_type == "date") {
-            data[[col]] <- as.Date(data[[col]])
-          } else if (target_type == "logical") {
-            data[[col]] <- as.logical(data[[col]])
-          } else if (target_type == "character") {
-            data[[col]] <- as.character(data[[col]])
-          } else if (target_type == "numeric") {
-            data[[col]] <- as.numeric(data[[col]])
+        converted <- tryCatch(
+          suppressWarnings(coerce_column(data[[col]], target_type)),
+          error = function(e) {
+            cli::cli_alert_info("Could not convert {col} to {target_type}: {e$message}")
+            NULL
           }
-        }, error = function(e) {
-          cli::cli_alert_info("Could not convert {col} to {target_type}: {e$message}")
-        })
+        )
+
+        if (is.null(converted)) {
+          next
+        }
+
+        # A coercion that turns real values into NA is data loss, not
+        # standardization: databaseId becomes database_id upstream and matches
+        # "_id$", but holds names like "db_alpha" that have no integer form.
+        if (anyNA(converted[!is.na(data[[col]])])) {
+          cli::cli_alert_info(
+            "Skipping {col}: converting to {target_type} would discard values"
+          )
+          next
+        }
+
+        data[[col]] <- converted
       }
     }
   }

--- a/R/disseminate.R
+++ b/R/disseminate.R
@@ -271,7 +271,7 @@ prepareDisseminationData <- function(
 
   checkmate::assert_data_frame(data)
   checkmate::assert_logical(c(clean_names, format_percentages, format_floats, standardize_types),
-    len = 1, any.missing = FALSE
+    len = 4, any.missing = FALSE
   )
 
   cli::cli_rule("Prepare Dissemination Data")

--- a/inst/templates/disseminationScript_template.R
+++ b/inst/templates/disseminationScript_template.R
@@ -73,8 +73,8 @@ if (length(result_files) > 0) {
   cat("Dimensions:", nrow(results_df), "rows ×", ncol(results_df), "columns\n")
   
   # Show which databases are in this result
-  if ("database_id" %in% names(results_df)) {
-    cat("Databases in this result:", paste(unique(results_df$database_id), collapse = ", "), "\n")
+  if ("databaseId" %in% names(results_df)) {
+    cat("Databases in this result:", paste(unique(results_df$databaseId), collapse = ", "), "\n")
   }
   cat("\n")
   
@@ -99,17 +99,17 @@ if (length(result_files) > 0) {
 # 3. Example: Pivot Results for Cross-Database Comparison
 # ============================================================================
 
-# If your results have a 'databaseId' column, you can create a wide pivot
-# for easy comparison across databases
+# Merged results carry a 'databaseId' column added by the postprocessing step.
+# prepareDisseminationData(clean_names = TRUE) renames it to 'database_id', so
+# use the snake_case name on formatted_df.
 
 # Uncomment and modify to use:
 # 
-# # Assuming 'databaseId' column exists for grouping
 # comparison_df <- picard::pivotForComparison(
 #   data = formatted_df,
-#   pivotColumns = c("metric_name", "stratum"),  # Columns to pivot
-#   valueColumn = "estimate",                     # Column with values
-#   databaseId = "databaseId"                     # Grouping column
+#   id_cols = c("metric_name", "stratum"),  # Columns identifying each row
+#   names_from = "database_id",             # Column pivoted into new columns
+#   values_from = "estimate"                # Column with values
 # )
 # 
 # output_comparison <- file.path(outputPath, "comparison_wide.csv")

--- a/man/standardizeDataTypes.Rd
+++ b/man/standardizeDataTypes.Rd
@@ -27,4 +27,8 @@ Default type conversions:
 \item Columns named "*_count": convert to integer
 \item Columns containing "flag" or "indicator": convert to logical
 }
+
+A conversion is only applied if it preserves every non-missing value. A
+column that matches a rule but cannot be coerced without introducing \code{NA}
+(for example a character \code{database_id}) is left as-is and reported.
 }

--- a/tests/testthat/test-disseminate.R
+++ b/tests/testthat/test-disseminate.R
@@ -51,8 +51,9 @@ testthat::test_that("importAndBind labels merged results with databaseId", {
     )
   )
 
+  # importAndBind() prefixes merged files with the task sequence from taskName
   merged <- readr::read_csv(
-    fs::path(root, "dissemination", "export", "merge", "cohort_counts.csv"),
+    fs::path(root, "dissemination", "export", "merge", "01_cohort_counts.csv"),
     show_col_types = FALSE
   )
 

--- a/tests/testthat/test-disseminate.R
+++ b/tests/testthat/test-disseminate.R
@@ -1,0 +1,141 @@
+# Purpose: Build a minimal temp project with per-database task results plus a
+# config.yml, mirroring the layout importAndBind() expects.
+diss_test_results_project <- function(test_name = "diss") {
+  root <- fs::file_temp(pattern = paste0("picard-", test_name, "-"))
+  fs::dir_create(root)
+
+  writeLines(
+    c(
+      "default:",
+      "  databaseName: \"db_alpha\"",
+      "",
+      "db_alpha:",
+      "  databaseName: \"db_alpha\"",
+      "",
+      "db_beta:",
+      "  databaseName: \"db_beta\""
+    ),
+    fs::path(root, "config.yml")
+  )
+
+  for (db in c("db_alpha", "db_beta")) {
+    task_dir <- fs::path(root, "exec", "results", db, "1.0.0", "01_counts")
+    fs::dir_create(task_dir, recurse = TRUE)
+    readr::write_csv(
+      tibble::tibble(
+        cohortId = c(1L, 2L),
+        cohortLabel = c("target", "comparator"),
+        count = c(10L, 20L)
+      ),
+      fs::path(task_dir, "cohort_counts.csv")
+    )
+  }
+
+  return(root)
+}
+
+# Testing: merged results carry the camelCase `databaseId` column, which is the
+# name the dissemination script template must look for (issue #87).
+testthat::test_that("importAndBind labels merged results with databaseId", {
+  root <- diss_test_results_project("diss-merge")
+  old_wd <- setwd(root)
+  on.exit(setwd(old_wd), add = TRUE)
+
+  suppressMessages(
+    importAndBind(
+      version = "1.0.0",
+      taskName = "01_counts",
+      dbIds = c("db_alpha", "db_beta"),
+      resultsPath = fs::path(root, "exec", "results"),
+      exportPath = fs::path(root, "dissemination", "export", "merge")
+    )
+  )
+
+  merged <- readr::read_csv(
+    fs::path(root, "dissemination", "export", "merge", "cohort_counts.csv"),
+    show_col_types = FALSE
+  )
+
+  testthat::expect_true("databaseId" %in% names(merged))
+  testthat::expect_false("database_id" %in% names(merged))
+  testthat::expect_setequal(unique(merged$databaseId), c("db_alpha", "db_beta"))
+})
+
+# Testing: the shipped dissemination template inspects the merged results with
+# the same column name importAndBind() writes.
+testthat::test_that("dissemination script template reads databaseId from merged results", {
+  template_path <- fs::path_package("picard", "templates", "disseminationScript_template.R")
+  testthat::skip_if_not(fs::file_exists(template_path))
+
+  template <- readr::read_file(template_path)
+
+  testthat::expect_true(
+    grepl("\"databaseId\" %in% names(results_df)", template, fixed = TRUE)
+  )
+  testthat::expect_false(grepl("results_df$database_id", template, fixed = TRUE))
+})
+
+# Testing: cleanColumnNames() is what turns databaseId into database_id, so the
+# snake_case references later in the template apply to formatted data only.
+testthat::test_that("cleanColumnNames converts databaseId to database_id", {
+  cleaned <- cleanColumnNames(
+    tibble::tibble(databaseId = "db_alpha", cohortId = 1L)
+  )
+
+  testthat::expect_equal(names(cleaned), c("database_id", "cohort_id"))
+})
+
+# Testing: prepareDisseminationData() accepts its four scalar flags. The
+# argument check asserted a length of 1 on a length-4 vector, so every call
+# aborted before any formatting ran (issue #87).
+testthat::test_that("prepareDisseminationData runs with default flags", {
+  data <- tibble::tibble(
+    databaseId = c("db_alpha", "db_beta"),
+    cohortLabel = c("target", "target"),
+    count = c(10L, 20L),
+    prevalencePct = c(0.1234, 0.5678),
+    estimate = c(1.2345, 2.3456)
+  )
+
+  result <- suppressWarnings(suppressMessages(prepareDisseminationData(data)))
+
+  testthat::expect_s3_class(result, "data.frame")
+  testthat::expect_true(all(c("database_id", "cohort_label", "prevalence_pct") %in% names(result)))
+  testthat::expect_equal(nrow(result), 2L)
+  testthat::expect_equal(result$prevalence_pct, c("12.3%", "56.8%"))
+})
+
+# Testing: each formatting step can still be switched off individually.
+testthat::test_that("prepareDisseminationData honours individually toggled flags", {
+  data <- tibble::tibble(
+    databaseId = c("db_alpha", "db_beta"),
+    estimate = c(1.2345, 2.3456)
+  )
+
+  result <- suppressWarnings(suppressMessages(
+    prepareDisseminationData(
+      data,
+      clean_names = FALSE,
+      format_percentages = FALSE,
+      format_floats = TRUE,
+      standardize_types = FALSE
+    )
+  ))
+
+  testthat::expect_true("databaseId" %in% names(result))
+  testthat::expect_equal(result$estimate, c("1.23", "2.35"))
+})
+
+# Testing: the flag check still rejects non-scalar or missing flags.
+testthat::test_that("prepareDisseminationData rejects non-scalar flags", {
+  data <- tibble::tibble(databaseId = "db_alpha", estimate = 1.5)
+
+  testthat::expect_error(
+    suppressMessages(prepareDisseminationData(data, clean_names = c(TRUE, FALSE))),
+    regexp = "length"
+  )
+  testthat::expect_error(
+    suppressMessages(prepareDisseminationData(data, format_floats = NA)),
+    regexp = "missing"
+  )
+})

--- a/tests/testthat/test-disseminate.R
+++ b/tests/testthat/test-disseminate.R
@@ -140,3 +140,51 @@ testthat::test_that("prepareDisseminationData rejects non-scalar flags", {
     regexp = "missing"
   )
 })
+
+# Testing: standardizeDataTypes() must not destroy columns that match a type
+# rule but cannot be coerced to it. The "_id$" rule matches the character
+# database_id column produced by cleanColumnNames() (issue #87 follow-up).
+testthat::test_that("standardizeDataTypes preserves character id columns", {
+  data <- tibble::tibble(
+    database_id = c("db_alpha", "db_beta"),
+    cohort_id = c("1", "2"),
+    person_count = c("10", "20")
+  )
+
+  result <- suppressMessages(standardizeDataTypes(data))
+
+  testthat::expect_identical(result$database_id, c("db_alpha", "db_beta"))
+  testthat::expect_identical(result$cohort_id, c(1L, 2L))
+  testthat::expect_identical(result$person_count, c(10L, 20L))
+})
+
+testthat::test_that("standardizeDataTypes reports the columns it skips", {
+  data <- tibble::tibble(database_id = c("db_alpha", "db_beta"))
+
+  testthat::expect_message(
+    standardizeDataTypes(data),
+    "Skipping database_id"
+  )
+})
+
+testthat::test_that("standardizeDataTypes keeps genuine NA values", {
+  data <- tibble::tibble(cohort_id = c("1", NA, "3"))
+
+  result <- suppressMessages(standardizeDataTypes(data))
+
+  testthat::expect_identical(result$cohort_id, c(1L, NA_integer_, 3L))
+})
+
+# Testing: the full default-flag path an analyst actually calls, end to end.
+testthat::test_that("prepareDisseminationData does not blank out databaseId", {
+  data <- tibble::tibble(
+    databaseId = c("db_alpha", "db_beta"),
+    cohortId = c(1L, 2L),
+    personCount = c(10L, 20L)
+  )
+
+  result <- suppressMessages(prepareDisseminationData(data))
+
+  testthat::expect_identical(result$database_id, c("db_alpha", "db_beta"))
+  testthat::expect_false(anyNA(result$database_id))
+})


### PR DESCRIPTION
Fixes #87. Both reported diagnoses were correct.

### 1. `prepareDisseminationData()` was entirely non-functional

```r
checkmate::assert_logical(c(clean_names, format_percentages, format_floats, standardize_types),
  len = 1, any.missing = FALSE
)
```

Four flags concatenated into one length-4 vector, asserted to have length 1. This fired on **every** call including all-default ones, so the function always aborted with `Must have length 1, but has length 4`. The formatting step documented in `vignettes/post_processing.Rmd` and used by generated dissemination scripts could never have run. Changed to `len = 4`, which still rejects non-scalar or `NA` flags.

### 2. Template checked for the wrong column name

The section-2 guard tested `"database_id" %in% names(results_df)` against the *raw* merged CSV. `importAndBind()` labels merged results with camelCase `databaseId` (`R/postProcess.R:133`), and `validateResultsColumns()` requires it — so the check was always FALSE and the "Databases in this result" line silently never printed.

Worth noting for review: **not every `database_id` in that template was wrong.** The occurrences further down operate on `formatted_df`, i.e. after `prepareDisseminationData(clean_names = TRUE)`, and `cleanColumnNames()` maps `databaseId` → `database_id`. Those are correct and are left alone. Only the pre-formatting check was the bug, which matches the reported line exactly. A comment now explains when each casing applies.

Also fixes the adjacent commented pivot example, which used the wrong casing *and* called `pivotForComparison()` with argument names that don't exist (`pivotColumns`/`valueColumn`/`databaseId` vs. the real `id_cols`/`names_from`/`values_from`).

### 3. Follow-on: `standardizeDataTypes()` silently blanked `database_id`

Surfaced by fixing (1) — the code path was dead before, and fixing it makes this live.

The default `_id$` rule matched the character `database_id` column and ran `as.integer()` on it. The surrounding `tryCatch` only caught *errors*, but failed coercion is a **warning**, so the column silently became all `NA`. Any conversion that would turn a non-missing value into `NA` is now skipped and reported; `cohort_id`/`person_count` still convert, and genuine `NA`s are preserved.

### Testing

`FAIL 4 | PASS 471` vs. a `develop` baseline of `FAIL 4 | PASS 450`. Identical failure set; the 4 are pre-existing.

10 new tests. The regressions for both reported bugs and for the `NA`-coercion fix were each verified to fail against the pre-fix code.

Swept the repo for repeats of both mistakes: `database_id` appears nowhere else outside that template, and `assert_*(c(...), len = ...)` on a concatenated vector occurs exactly once in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QquaXJZxgCaEFtUTHVioG1