### PR TITLE
Canonicalize ATLAS concept set ordering before serialization (part of #84)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - remove function forced tags `route = atlas` or `route = capr` (See Issue #67)
 - in `$grabConceptInfoFromSet()` change input to conceptSetRef which accepts either a manifest id or a label (See issue #56)
 - Add task prefix to the `importAndBind()` save to avoid similar output names between tasks.
+- Concept sets fetched from ATLAS came back with their concepts in a nondeterministic order, so an unchanged definition serialized to different JSON — and a different content hash — on every fetch, dirtying the study repo's git status (part of #84). Concept set expressions are now canonicalized before serialization: items are ordered by `CONCEPT_ID` (ties broken by vocabulary, code and inclusion flags) and circe `ConceptSets` by their `id`. Ordering is left untouched when any concept set lacks a usable `id`, so `CodesetId` references cannot break.
 - Add method to ExecutionSettings to `reviewConnectionDetails()` pulls the connectionDetails used. 
 - Modify `getServerCredentials()` to not evaluate full yml file, only pull the specific block and evaluate (See issue #30, #33). 
 - Fix `makeDisseminationScript()` change the glue brackets to carrots

--- a/R/WebApi.R
+++ b/R/WebApi.R
@@ -329,15 +329,115 @@ pluckConceptSetExpression <- function(conceptSetId, baseUrl, bearerToken) {
     httr2::req_auth_bearer_token(token = bearerToken)
   resp <- httr2::req_perform(req = req)
   csExp <- httr2::resp_body_json(resp)
-  csExp2 <- RJSONIO::toJSON(csExp, digits = 23, pretty = TRUE)
+  csExp2 <- RJSONIO::toJSON(
+    canonicalize_concept_set_expression(csExp),
+    digits = 23,
+    pretty = TRUE
+  )
   return(csExp2)
+}
+
+# ATLAS returns the concepts of a concept set in a nondeterministic order, so an
+# unchanged definition can serialize to a different JSON string on every fetch.
+# That churns the on-disk JSON file, its content hash and therefore the manifest
+# sqlite file, which then shows up as an uncommitted change in git. Ordering the
+# concepts by a stable key makes the fetch reproducible. A concept set
+# expression is a set of items — reordering them does not change its meaning,
+# and circe resolves concept sets by `id`, not by position.
+
+# Safely read a named element from a parsed JSON node, which RJSONIO/httr2 may
+# hand back as either a named list or a named atomic vector.
+pluck_json_field <- function(x, name) {
+  if (is.null(x) || is.null(names(x)) || !(name %in% names(x))) {
+    return(NULL)
+  }
+  x[[name]]
+}
+
+# Build the sort key for one concept set item. CONCEPT_ID is the primary key,
+# zero-padded so it sorts numerically; vocabulary, code and the inclusion flags
+# break ties so items that share a concept still order deterministically.
+concept_set_item_key <- function(item) {
+  concept <- pluck_json_field(item, "concept")
+
+  conceptField <- function(name) {
+    value <- pluck_json_field(concept, name)
+    if (is.null(value) || length(value) != 1 || is.na(value)) "" else as.character(value)
+  }
+
+  itemFlag <- function(name) {
+    if (isTRUE(pluck_json_field(item, name))) "1" else "0"
+  }
+
+  rawId <- conceptField("CONCEPT_ID")
+  numericId <- suppressWarnings(as.numeric(rawId))
+  idKey <- if (is.na(numericId)) paste0("z", rawId) else sprintf("%020.0f", numericId)
+
+  paste(
+    idKey,
+    conceptField("VOCABULARY_ID"),
+    conceptField("CONCEPT_CODE"),
+    itemFlag("isExcluded"),
+    itemFlag("includeDescendants"),
+    itemFlag("includeMapped"),
+    sep = "|"
+  )
+}
+
+# Sort the `items` of a concept set expression by concept, leaving every other
+# element of the expression untouched.
+canonicalize_concept_set_expression <- function(expression) {
+  items <- pluck_json_field(expression, "items")
+
+  if (!is.list(items) || length(items) < 2) {
+    return(expression)
+  }
+
+  keys <- vapply(items, concept_set_item_key, character(1))
+  expression[["items"]] <- items[order(keys, method = "radix")]
+  expression
+}
+
+# Canonicalize the ConceptSets block of a circe cohort expression: sort each
+# concept set's items, then order the concept sets by their circe id.
+canonicalize_circe_concept_sets <- function(conceptSets) {
+  if (!is.list(conceptSets) || length(conceptSets) == 0) {
+    return(conceptSets)
+  }
+
+  conceptSets <- lapply(conceptSets, function(conceptSet) {
+    if (!is.list(conceptSet)) {
+      return(conceptSet)
+    }
+    expression <- pluck_json_field(conceptSet, "expression")
+    if (!is.null(expression)) {
+      conceptSet[["expression"]] <- canonicalize_concept_set_expression(expression)
+    }
+    conceptSet
+  })
+
+  ids <- vapply(conceptSets, function(conceptSet) {
+    id <- pluck_json_field(conceptSet, "id")
+    if (is.null(id) || length(id) != 1) {
+      return(NA_real_)
+    }
+    suppressWarnings(as.numeric(id))
+  }, numeric(1))
+
+  # Without a usable id on every concept set, leave the order alone rather than
+  # risk reordering against the codeset references in the cohort expression
+  if (anyNA(ids)) {
+    return(conceptSets)
+  }
+
+  conceptSets[order(ids)]
 }
 
 
 formatCohortExpression <- function(expression) {
   # reformat to standard circe
   circe <- list(
-    'ConceptSets' = expression$ConceptSets,
+    'ConceptSets' = canonicalize_circe_concept_sets(expression$ConceptSets),
     'PrimaryCriteria' = expression$PrimaryCriteria,
     'AdditionalCriteria' = expression$AdditionalCriteria,
     'QualifiedLimit' = expression$QualifiedLimit,

--- a/tests/testthat/test-WebApi-canonicalize.R
+++ b/tests/testthat/test-WebApi-canonicalize.R
@@ -1,0 +1,156 @@
+# Purpose: Build a concept set item shaped like the JSON ATLAS returns.
+wa_test_item <- function(conceptId, excluded = FALSE, descendants = TRUE) {
+  list(
+    concept = list(
+      CONCEPT_ID = conceptId,
+      CONCEPT_NAME = paste("concept", conceptId),
+      VOCABULARY_ID = "SNOMED",
+      CONCEPT_CODE = as.character(conceptId)
+    ),
+    isExcluded = excluded,
+    includeDescendants = descendants,
+    includeMapped = FALSE
+  )
+}
+
+# Purpose: Pull the CONCEPT_IDs out of a canonicalized expression, in order.
+wa_test_concept_ids <- function(expression) {
+  vapply(expression$items, function(item) as.numeric(item$concept$CONCEPT_ID), numeric(1))
+}
+
+# Testing: concept set items are ordered by CONCEPT_ID regardless of the order
+# ATLAS returned them in (issue #84).
+testthat::test_that("canonicalize_concept_set_expression sorts items by CONCEPT_ID", {
+  expression <- list(items = list(
+    wa_test_item(443238),
+    wa_test_item(201826),
+    wa_test_item(4193704)
+  ))
+
+  out <- canonicalize_concept_set_expression(expression)
+
+  testthat::expect_equal(wa_test_concept_ids(out), c(201826, 443238, 4193704))
+})
+
+# Testing: any permutation of the same items canonicalizes to the same JSON, so
+# the on-disk file and its content hash stay stable across ATLAS fetches.
+testthat::test_that("canonicalize_concept_set_expression is order-invariant", {
+  items <- list(wa_test_item(443238), wa_test_item(201826), wa_test_item(4193704))
+
+  serialize <- function(order) {
+    RJSONIO::toJSON(
+      canonicalize_concept_set_expression(list(items = items[order])),
+      digits = 23,
+      pretty = TRUE
+    )
+  }
+
+  permutations <- list(c(1, 2, 3), c(3, 2, 1), c(2, 1, 3), c(2, 3, 1))
+  serialized <- vapply(permutations, serialize, character(1))
+
+  testthat::expect_equal(length(unique(serialized)), 1)
+  testthat::expect_equal(
+    rlang::hash(serialized[[1]]),
+    rlang::hash(serialized[[length(serialized)]])
+  )
+})
+
+# Testing: items sharing a CONCEPT_ID but differing in inclusion flags still get a
+# deterministic order, and no item is dropped.
+testthat::test_that("canonicalize_concept_set_expression keeps every item", {
+  items <- list(
+    wa_test_item(201826, excluded = TRUE),
+    wa_test_item(201826, excluded = FALSE),
+    wa_test_item(201826, excluded = FALSE, descendants = FALSE)
+  )
+
+  first <- canonicalize_concept_set_expression(list(items = items))
+  second <- canonicalize_concept_set_expression(list(items = rev(items)))
+
+  testthat::expect_equal(length(first$items), 3)
+  testthat::expect_equal(first$items, second$items)
+})
+
+# Testing: non-item elements of the expression are left untouched.
+testthat::test_that("canonicalize_concept_set_expression preserves other fields", {
+  expression <- list(
+    items = list(wa_test_item(443238), wa_test_item(201826)),
+    extra = "keep me"
+  )
+
+  out <- canonicalize_concept_set_expression(expression)
+
+  testthat::expect_equal(out$extra, "keep me")
+  testthat::expect_equal(names(out), names(expression))
+})
+
+# Testing: expressions with no items, or a single item, pass through unchanged.
+testthat::test_that("canonicalize_concept_set_expression tolerates empty expressions", {
+  testthat::expect_equal(
+    canonicalize_concept_set_expression(list(items = list())),
+    list(items = list())
+  )
+  testthat::expect_equal(
+    canonicalize_concept_set_expression(list(other = 1)),
+    list(other = 1)
+  )
+})
+
+# Testing: the ConceptSets block of a circe cohort is ordered by concept set id,
+# with each concept set's items ordered by CONCEPT_ID.
+testthat::test_that("canonicalize_circe_concept_sets sorts concept sets and their items", {
+  conceptSets <- list(
+    list(id = 2, name = "second",
+         expression = list(items = list(wa_test_item(443238), wa_test_item(201826)))),
+    list(id = 0, name = "first",
+         expression = list(items = list(wa_test_item(4193704))))
+  )
+
+  out <- canonicalize_circe_concept_sets(conceptSets)
+
+  testthat::expect_equal(vapply(out, function(cs) cs$id, numeric(1)), c(0, 2))
+  testthat::expect_equal(wa_test_concept_ids(out[[2]]$expression), c(201826, 443238))
+})
+
+# Testing: concept sets missing an id keep their original order, so codeset
+# references in the cohort expression cannot be broken.
+testthat::test_that("canonicalize_circe_concept_sets leaves order alone without ids", {
+  conceptSets <- list(
+    list(name = "second", expression = list(items = list(wa_test_item(443238)))),
+    list(name = "first", expression = list(items = list(wa_test_item(201826))))
+  )
+
+  out <- canonicalize_circe_concept_sets(conceptSets)
+
+  testthat::expect_equal(vapply(out, function(cs) cs$name, character(1)), c("second", "first"))
+})
+
+# Testing: a shuffled ATLAS cohort payload serializes to identical circe JSON.
+testthat::test_that("formatCohortExpression is stable under shuffled concept order", {
+  makeExpression <- function(itemOrder, conceptSetOrder) {
+    conceptSets <- list(
+      list(id = 0, name = "target",
+           expression = list(items = list(
+             wa_test_item(201826), wa_test_item(443238), wa_test_item(4193704)
+           )[itemOrder])),
+      list(id = 1, name = "outcome",
+           expression = list(items = list(wa_test_item(192671))))
+    )
+    list(
+      ConceptSets = conceptSets[conceptSetOrder],
+      PrimaryCriteria = list(CriteriaList = list()),
+      QualifiedLimit = list(Type = "First"),
+      ExpressionLimit = list(Type = "First"),
+      InclusionRules = list(),
+      CensoringCriteria = list(),
+      CollapseSettings = list(CollapseType = "ERA", EraPad = 0),
+      CensorWindow = list(),
+      cdmVersionRange = ">=5.0.0"
+    )
+  }
+
+  first <- formatCohortExpression(makeExpression(c(1, 2, 3), c(1, 2)))
+  second <- formatCohortExpression(makeExpression(c(3, 1, 2), c(2, 1)))
+
+  testthat::expect_equal(rlang::hash(first), rlang::hash(second))
+})


### PR DESCRIPTION
Split out of #88 (part of #84), so it can be weighed on its own merits.

### The bug

ATLAS returns the concepts of a concept set in a nondeterministic order. Picard both **writes that JSON to disk** and **hashes it for change detection**, so a re-fetch of an entirely unedited concept set can produce a different byte sequence, a different content hash, a rewritten `inputs/conceptSets/*.json` (or `inputs/cohorts/json/*.json`), and a rewritten manifest sqlite. A reshuffle looks exactly like a real edit: the study repo's git status goes dirty for no semantic reason, and `validateCodeState()` fails the pipeline's pre-flight check.

### What this does

`canonicalize_concept_set_expression()` orders a concept set's `items` by `CONCEPT_ID` (ties broken by `VOCABULARY_ID`, `CONCEPT_CODE` and the `isExcluded` / `includeDescendants` / `includeMapped` flags). `canonicalize_circe_concept_sets()` applies that to each concept set inside a circe cohort expression and then orders the `ConceptSets` block by circe `id`. They are wired into `pluckConceptSetExpression()` and `formatCohortExpression()`.

### The contentious part

**This canonicalizes *before* serialization, so it changes the bytes written to disk — not just the comparison.** It would have been possible to normalize only at hash-comparison time and leave the fetched JSON byte-for-byte as ATLAS sent it. This PR does not do that: the file on disk is Picard's re-ordering of ATLAS's payload. That is the judgment call worth arguing about, and it is why this is a separate PR.

A concept set is a set — reordering its items does not change its meaning, and circe resolves concept sets by `id`, not by position — so the rewrite is semantically inert. But it is still Picard rewriting a user-facing artifact that an analyst may reasonably expect to match what ATLAS returned.

### One-time migration effect

The first import after this merges will rewrite every existing concept set and circe cohort JSON file into sorted order. In an established study repo that is a large one-off diff across files nobody edited.

**Recommendation:** land this, run one import, and commit that reshuffle as its own commit with a message explaining it, separate from any substantive change. After that first pass the files are stable.

### Safety guard

`canonicalize_circe_concept_sets()` reorders the `ConceptSets` block only when *every* concept set carries a usable numeric `id`. If any is missing or unparseable, the original order is returned untouched. This is deliberate: `CodesetId` references elsewhere in the cohort expression point at those ids, and reordering an id-less list could silently repoint criteria at the wrong concept set. Item-level sorting inside each concept set is always safe and is applied regardless.

### Root cause is probably upstream

The nondeterminism originates in OHDSI WebAPI's concept set endpoints, not in Picard. That is being reported upstream separately. If it is fixed there, this canonicalization becomes redundant (though harmless — it would be a no-op on already-ordered input). Treat this as a stopgap that buys usable pre-flight checks in the meantime, not as the permanent home for the fix.

### Testing, and its limits

`FAIL 4 | PASS 463` vs. a `develop` baseline of `FAIL 4 | PASS 450`. Identical failure set — the 4 are pre-existing (`addCaprCohort`, `getCohortsByLabel`, and a missing `death.json` fixture in `test-make.R`).

`tests/testthat/test-WebApi-canonicalize.R` permutes a synthetic ATLAS-shaped payload and asserts that the serialized JSON and its `rlang::hash()` are invariant across permutations, that no item is dropped, that non-`items` fields survive, that empty/single-item expressions pass through, and that the id-less guard holds.

The reordering itself has been confirmed against a live ATLAS instance. The automated tests, however, run against a payload we construct: they prove the canonicalization is correct and order-invariant, not that ATLAS reordering is the only source of JSON churn in a given study repo. If churn persists after this, look elsewhere for the remaining cause.

The root cause has been traced to WebAPI's `findAllByConceptSetId` in `ConceptSetItemRepository`, which is a Spring Data derived query with no `OrderBy` suffix, no `Sort` parameter and no `ORDER BY`, over a `concept_set_item` table that has no index on `concept_set_id`. Row order is therefore formally unspecified, and an unordered scan can genuinely return different orders across identical queries with no data change. This is being reported upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QquaXJZxgCaEFtUTHVioG1

