### PR TITLE
Sync agent docs with vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Modify `getServerCredentials()` to not evaluate full yml file, only pull the specific block and evaluate (See issue #30, #33). 
 - Fix `makeDisseminationScript()` change the glue brackets to carrots
 - Fix bug in `$updateAtlasCohorts()`/`$updateAtlasConceptSets()` to use tags in json mode after tab format change. 
+- Regenerated `inst/agent/05-manifest-management.md` from `vignettes/manifest_management.Rmd`. It had not been synced since `viewManifest()` and the `tabulateManifest(tags_format = ...)` options were added, so agents in generated study repos were reading stale manifest guidance.
 
 # picard 0.0.6
 

--- a/inst/agent/05-manifest-management.md
+++ b/inst/agent/05-manifest-management.md
@@ -325,14 +325,60 @@ csm <- loadConceptSetManifest(autoSync = TRUE, verbose = TRUE)
 
 ### Cohort manifest
 
+#### Tabulating and Viewing Manifest Data
+
+The manifest provides two methods for viewing cohort metadata:
+
+**Interactive Viewing (Recommended for Exploration)**
+
 ```{r}
-# Full tabular view (all active cohorts)
-manifest$tabulateManifest()
+# Open an interactive RStudio viewer with streamlined metadata
+# Shows: id, label, category, tags, file_path
+manifest$viewManifest()
 
-# Filter to stale cohorts only
-manifest$tabulateManifest(filter = "stale")
+# Filter to specific status
+manifest$viewManifest(filter = "active")
+manifest$viewManifest(filter = "stale")
+manifest$viewManifest(filter = "deleted")
 
-# Stale cohorts with dependency context
+# Control tag format in the viewer:
+# - nested (default): tags as structured tibble with tag_name/tag_value
+# - json: tags as raw JSON string
+# - wide: tags expanded into individual columns
+manifest$viewManifest(tags_format = "nested")
+manifest$viewManifest(tags_format = "wide")  # Excel-like view
+```
+
+**Programmatic Tabulation (for pipelines/analysis)**
+
+```{r}
+# Full tabular view with all columns (id, label, category, tags, file_path, hash, source_type, cohort_type, status, depends_on, created_at, deleted_at)
+tbl <- manifest$tabulateManifest()
+
+# Filter by status
+stale_cohorts <- manifest$tabulateManifest(filter = "stale")
+deleted_cohorts <- manifest$tabulateManifest(filter = "deleted")
+all_cohorts <- manifest$tabulateManifest(filter = "all")
+
+# Control tag format
+# Option 1: nested (default) - tags as nested tibble with tag_name/tag_value pairs
+tbl_nested <- manifest$tabulateManifest(tags_format = "nested")
+# Access nested tags: tbl_nested$tags[[1]] returns a tibble of tag pairs
+
+# Option 2: json (backward compatible) - tags as raw JSON string
+tbl_json <- manifest$tabulateManifest(tags_format = "json")
+# Useful for APIs or custom tag parsing
+
+# Option 3: wide - tags expanded into individual columns
+# Creates one column per unique tag key across the manifest
+tbl_wide <- manifest$tabulateManifest(tags_format = "wide")
+# Columns like: id, label, category, file_path, hash, status, approval_status, domain, etc.
+```
+
+#### Other Cohort Review Methods
+
+```{r}
+# Stale cohorts (files changed since last execution, need regeneration)
 manifest$reviewStaleCohorts()
 
 # Derived cohorts only — with parent labels and rule summaries
@@ -347,19 +393,25 @@ plotCohortGraph(manifest)
 ```{r}
 csm <- loadConceptSetManifest(autoSync = TRUE, verbose = TRUE)
 
-# Tabular view of all concept sets
-csm$tabulateManifest()
+# Interactive view (recommended for exploring)
+csm$viewManifest()
+csm$viewManifest(tags_format = "wide")
+
+# Programmatic access with different tag formats
+tbl_nested <- csm$tabulateManifest(tags_format = "nested")  # default
+tbl_json <- csm$tabulateManifest(tags_format = "json")
+tbl_wide <- csm$tabulateManifest(tags_format = "wide")
 
 # Extract concept set member codes (standard concept IDs)
 csm$extractIncludedCodes(
-  conceptSetIds = c(1L, 2L, 3L)
+  outputFolder = here::here("inputs/conceptSets")
 )
 
 # Extract source codes mapped from concept set members
 # Useful for inspecting ICD-10, NDC, etc. coverage
 csm$extractSourceCodes(
-  conceptSetIds  = c(1L, 2L),
-  sourceVocabs   = c("ICD10CM", "ICD9CM")
+  sourceVocabs = c("ICD10CM", "ICD9CM"),
+  outputFolder = here::here("inputs/conceptSets")
 )
 ```
 


### PR DESCRIPTION
`inst/agent/*.md` is generated from `vignettes/*.Rmd` and carries the `AUTO-GENERATED FILE. DO NOT EDIT DIRECTLY` header, but `inst/agent/05-manifest-management.md` had drifted from its source on `develop`.

It was missing the `viewManifest()` documentation and the `tabulateManifest(tags_format = ...)` options — `nested`, `json` and `wide` — that were added in 0.0.7. Since these files are installed into generated study repos as `.agent/`, an AI agent helping an analyst inside a study repo has been reading manifest guidance that predates those methods.

Regenerated with `sync_agent_docs_from_vignettes(dryRun = FALSE)` from `extras/zzz_maintenance.R`. Only this one file changed; the other eight were already in sync.

This was noticed while regenerating docs for #92, where the unrelated drift would otherwise have been swept into that PR's diff. Split out so the change is reviewable on its own.

No source or vignette content was edited — this is purely the generated output catching up to `vignettes/manifest_management.Rmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QquaXJZxgCaEFtUTHVioG1